### PR TITLE
Make Summary Stats available without data

### DIFF
--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -7,12 +7,15 @@ Description
 	description		: qsTr("ESCI in JASP")
 	icon		    : "esci_logo.svg"
 	hasWrappers		: false
+	requiresData	: false
+
 
 	Analysis
 	{
 		title:	qsTr("ESCI: Describe")
 		menu:	qsTr("Describe")
 		func:	"jasp_describe"
+		requiresData	: true
 	}
 
 	GroupTitle
@@ -46,6 +49,8 @@ Description
 		title:	qsTr("ESCI Means and Medians: Independent Groups Contrast")
 		menu:	qsTr("Independent Groups Contrast")
 		func:	"jasp_estimate_mdiff_ind_contrast"
+		requiresData	: true
+
 	}
 
 	Analysis
@@ -113,6 +118,7 @@ Description
 		title:	qsTr("ESCI Meta-Analysis: Means")
 		menu:	qsTr("Means")
 		func:	"jasp_meta_mean"
+		requiresData: true
 	}
 
 	Analysis
@@ -120,6 +126,7 @@ Description
 		title:	qsTr("ESCI Meta-Analysis: Difference in Means")
 		menu:	qsTr("Difference in Means")
 		func:	"jasp_meta_mdiff_two"
+		requiresData: true
 	}
 
 	Analysis
@@ -127,6 +134,7 @@ Description
 		title:	qsTr("ESCI Meta-Analysis: Correlations")
 		menu:	qsTr("Correlations")
 		func:	"jasp_meta_r"
+		requiresData: true
 	}
 
 	Analysis
@@ -134,13 +142,15 @@ Description
 		title:	qsTr("ESCI Meta-Analysis: Proportions")
 		menu:	qsTr("Proportions")
 		func:	"jasp_meta_proportion"
+		requiresData: true
 	}
 
 		Analysis
 	{
-	  title: qsTr("ESCI Meta-Anlaysis: Difference in Proportions")
+		title: qsTr("ESCI Meta-Anlaysis: Difference in Proportions")
 		menu:	qsTr("Difference in Proportions")
 		func:	"jasp_meta_pdiff_two"
+		requiresData: true
 	}
 
 }

--- a/inst/qml/esci/AestheticsAll.qml
+++ b/inst/qml/esci/AestheticsAll.qml
@@ -4,9 +4,12 @@ import JASP
 import JASP.Controls
 import "./" as Esci
 
-    Section
+  Section
   {
     title: qsTr("Aesthetics")
+
+    property bool is_summary:  false
+    property bool is_mixed:    false
 
     GridLayout {
       id: grid
@@ -38,23 +41,8 @@ import "./" as Esci
       }
 
       Label {
+        Layout.columnSpan: 5
         text: qsTr("<b>Summary</b>")
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
       }
 
       Label {
@@ -220,23 +208,8 @@ import "./" as Esci
       }
 
       Label {
+        Layout.columnSpan: 5
         text: "<b>CI</b>"
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
       }
 
       Label {
@@ -382,23 +355,8 @@ import "./" as Esci
       }
 
       Label {
+        Layout.columnSpan: 5
         text: qsTr("<b>Error distribution</b>")
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
       }
 
       Label {
@@ -475,24 +433,10 @@ import "./" as Esci
 
 
       Label {
+        Layout.columnSpan: 5
         text: qsTr("<b>Raw data</b>")
       }
 
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
-
-      Label {
-        text: " "
-      }
 
       Label {
         text: qsTr("Shape")
@@ -503,19 +447,16 @@ import "./" as Esci
         name: "shape_raw_reference"
         id: shape_raw_reference
         startValue: 'circle filled'
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
       }
 
       Esci.ShapeSelect
       {
+        Layout.columnSpan: 2
         name: "shape_raw_comparison"
         id: shape_raw_comparison
         startValue: 'circle filled'
-        enabled: from_raw.checked | mixed.checked
-      }
-
-      Label {
-        text: " "
+        enabled: !is_summary | is_mixed
       }
 
       Esci.ShapeSelect
@@ -523,7 +464,7 @@ import "./" as Esci
         name: "shape_raw_unused"
         id: shape_raw_unused
         startValue: 'circle filled'
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
       }
 
 
@@ -536,21 +477,18 @@ import "./" as Esci
         name: "size_raw_reference"
         id: size_raw_reference
         defaultValue: 2
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
 
       }
 
       Esci.SizeSelect
       {
+        Layout.columnSpan: 2
         name: "size_raw_comparison"
         id: size_raw_comparison
         defaultValue: 2
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
 
-      }
-
-      Label {
-        text: " "
       }
 
       Esci.SizeSelect
@@ -558,7 +496,7 @@ import "./" as Esci
         name: "size_raw_unused"
         id: size_raw_unused
         defaultValue: 1
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
       }
 
 
@@ -571,19 +509,16 @@ import "./" as Esci
         name: "color_raw_reference"
         id: color_raw_reference
         startValue: "#008DF9"
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
       }
 
       Esci.ColorSelect
       {
+        Layout.columnSpan: 2
         name: "color_raw_comparison"
         id: color_raw_comparison
         startValue: "#009F81"
-        enabled: from_raw.checked | mixed.checked
-      }
-
-      Label {
-        text: " "
+        enabled: !is_summary | is_mixed
       }
 
       Esci.ColorSelect
@@ -591,7 +526,7 @@ import "./" as Esci
         name: "color_raw_unused"
         id: color_raw_unused
         startValue: "gray65"
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
       }
 
 
@@ -604,19 +539,16 @@ import "./" as Esci
         name: "fill_raw_reference"
         id: fill_raw_reference
         startValue: "NA"
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
       }
 
       Esci.ColorSelect
       {
+        Layout.columnSpan: 2
         name: "fill_raw_comparison"
         id: fill_raw_comparison
         startValue: "NA"
-        enabled: from_raw.checked | mixed.checked
-      }
-
-      Label {
-        text: " "
+        enabled: !is_summary | is_mixed
       }
 
       Esci.ColorSelect
@@ -624,7 +556,7 @@ import "./" as Esci
         name: "fill_raw_unused"
         id: fill_raw_unused
         startValue: "NA"
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
       }
 
 
@@ -636,27 +568,24 @@ import "./" as Esci
       {
         name: "alpha_raw_reference"
         id: alpha_raw_reference
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
 
       }
 
       Esci.AlphaSelect
       {
+        Layout.columnSpan: 2
         name: "alpha_raw_comparison"
         id: alpha_raw_comparison
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
 
-      }
-
-      Label {
-        text: " "
       }
 
       Esci.AlphaSelect
       {
         name: "alpha_raw_unused"
         id: alpha_raw_unused
-        enabled: from_raw.checked | mixed.checked
+        enabled: !is_summary | is_mixed
 
       }
 

--- a/inst/qml/esci/AestheticsSummary.qml
+++ b/inst/qml/esci/AestheticsSummary.qml
@@ -4,69 +4,68 @@ import JASP
 import JASP.Controls
 import "./" as Esci
 
-    GridLayout
-    {
-    columns: 5
-    Layout.columnSpan: 2
-    rowSpacing:    jaspTheme.rowGroupSpacing
-    columnSpacing: jaspTheme.columnGroupSpacing
+GridLayout
+{
+  columns: 5
+  rowSpacing:    jaspTheme.rowGroupSpacing
+  columnSpacing: jaspTheme.columnGroupSpacing
 
-    Label { text: qsTr("<b>Summary</b>") }
+  Label { text: qsTr("<b>Summary</b>") }
 
-    Label { text: qsTr("Shape") }
+  Label { text: qsTr("Shape") }
 
-      Esci.ShapeSelect
-      {
-        name: "shape_summary"
-        id: shape_summary
-        fieldWidth: jaspTheme.textFieldWidth * 0.7
-      }
+  Esci.ShapeSelect
+  {
+    name: "shape_summary"
+    id: shape_summary
+    fieldWidth: jaspTheme.textFieldWidth * 0.7
+  }
 
-    Label { text: qsTr("Size") }
+  Label { text: qsTr("Size") }
 
-      Esci.SizeSelect
-      {
-        name: "size_summary"
-        fieldWidth: jaspTheme.textFieldWidth * 0.7
-      }
+  Esci.SizeSelect
+  {
+    name: "size_summary"
+    fieldWidth: jaspTheme.textFieldWidth * 0.7
+  }
 
-    Label { text: " " }
+  Label { text: " " }
 
-    Label { text: qsTr("Outline") }
+  Label { text: qsTr("Outline") }
 
-      Esci.ColorSelect
-      {
-        name: "color_summary"
-        startValue: '#008DF9'
-        id: color_summary
-        fieldWidth: jaspTheme.textFieldWidth * 0.7
-      }
+  Esci.ColorSelect
+  {
+    name: "color_summary"
+    startValue: '#008DF9'
+    id: color_summary
+    fieldWidth: jaspTheme.textFieldWidth * 0.7
+  }
 
-    Label { text: qsTr("Fill") }
+  Label { text: qsTr("Fill") }
 
-      Esci.ColorSelect
-      {
-        name: "fill_summary"
-        label: qsTr("Fill")
-        startValue: '#008DF9'
-        id: fill_summary
-        fieldWidth: jaspTheme.textFieldWidth * 0.7
-      }
+  Esci.ColorSelect
+  {
+    name: "fill_summary"
+    label: qsTr("Fill")
+    startValue: '#008DF9'
+    id: fill_summary
+    fieldWidth: jaspTheme.textFieldWidth * 0.7
+  }
 
-    Label { text: " " }
+  Label { text: " " }
 
-    Label { text: qsTr("Transparency") }
-
-
-      Esci.AlphaSelect
-      {
-        name: "alpha_summary"
-        fieldWidth: jaspTheme.textFieldWidth * 0.7
-      }
-
-      Label { text: " " }
-
-      Label { text: " " }
+  Label { text: qsTr("Transparency") }
 
 
-    }
+  Esci.AlphaSelect
+  {
+    name: "alpha_summary"
+    fieldWidth: jaspTheme.textFieldWidth * 0.7
+  }
+
+  Label { text: " " }
+
+  Label { text: " " }
+
+
+}

--- a/inst/qml/esci/FigureOptions.qml
+++ b/inst/qml/esci/FigureOptions.qml
@@ -11,7 +11,7 @@ import "./" as Esci
     property alias simple_labels_enabled: simple_contrast_labels.enabled
     property alias simple_labels_visible: simple_contrast_labels.visible
     property alias difference_axis_grid_visible: difference_axis_grid.visible
-	// property alias difference_axis_units_visible: difference_axis_units.visible
+    // property alias difference_axis_units_visible: difference_axis_units.visible
     property bool  difference_axis_units_visible: false
     property alias data_grid_visible: data_grid.visible
     property alias distributions_grid_visible: distributions_grid.visible
@@ -22,6 +22,8 @@ import "./" as Esci
     property alias error_nudge_defaultValue: error_nudge.defaultValue
     property alias data_spread_defaultValue: data_spread.defaultValue
     property alias error_scale_defaultValue: error_scale.defaultValue
+
+    property bool is_summary: false
 
 
     GridLayout
@@ -45,7 +47,7 @@ import "./" as Esci
         defaultValue: 300
         min: 100
         max: 3000
-		fieldWidth: dimensions_grid.adjustedFieldWidth
+        fieldWidth: dimensions_grid.adjustedFieldWidth
       }
 
       Label { text: qsTr("Height") }
@@ -56,7 +58,7 @@ import "./" as Esci
           defaultValue: 400
           min: 100
           max: 3000
-		  fieldWidth: dimensions_grid.adjustedFieldWidth
+          fieldWidth: dimensions_grid.adjustedFieldWidth
       }
       // end: Dimension
 
@@ -68,7 +70,7 @@ import "./" as Esci
       {
           name: "ylab"
           placeholderText: "auto"
-		      fieldWidth: dimensions_grid.adjustedFieldWidth * 2
+              fieldWidth: dimensions_grid.adjustedFieldWidth * 2
           Layout.columnSpan: 3
       }
 
@@ -83,7 +85,7 @@ import "./" as Esci
           defaultValue: 14
           min: 2
           max: 80
-		  fieldWidth: dimensions_grid.adjustedFieldWidth
+          fieldWidth: dimensions_grid.adjustedFieldWidth
       }
 
       Label { text: qsTr("Label font size") }
@@ -93,7 +95,7 @@ import "./" as Esci
           defaultValue: 15
           min: 2
           max: 80
-		  fieldWidth: dimensions_grid.adjustedFieldWidth
+          fieldWidth: dimensions_grid.adjustedFieldWidth
       }
       // end: y-axis row 2
 
@@ -106,7 +108,7 @@ import "./" as Esci
           name: "ymin"
           id: ymin
           placeholderText: "auto"
-		  fieldWidth: dimensions_grid.adjustedFieldWidth
+          fieldWidth: dimensions_grid.adjustedFieldWidth
       }
 
       Label { text: qsTr("Max") }
@@ -115,7 +117,7 @@ import "./" as Esci
           name: "ymax"
           id: ymax
           placeholderText: "auto"
-		  fieldWidth: dimensions_grid.adjustedFieldWidth
+          fieldWidth: dimensions_grid.adjustedFieldWidth
       }
       // end: y-axis row 3
 
@@ -127,7 +129,7 @@ import "./" as Esci
       {
           name: "ybreaks"
           placeholderText: "auto"
-		  fieldWidth: dimensions_grid.adjustedFieldWidth
+          fieldWidth: dimensions_grid.adjustedFieldWidth
       }
 
       Label { text: "" }
@@ -142,7 +144,7 @@ import "./" as Esci
       {
           name: "xlab"
           placeholderText: "auto"
-		      fieldWidth: dimensions_grid.adjustedFieldWidth * 2
+              fieldWidth: dimensions_grid.adjustedFieldWidth * 2
           Layout.columnSpan: 3      }
 
       // end: x-axis row 1
@@ -158,7 +160,7 @@ import "./" as Esci
         defaultValue: 14
         min: 2
         max: 80
-		    fieldWidth: dimensions_grid.adjustedFieldWidth
+            fieldWidth: dimensions_grid.adjustedFieldWidth
       }
 
       Label { text: qsTr("Label font size") }
@@ -168,7 +170,7 @@ import "./" as Esci
         defaultValue: 15
         min: 2
         max: 80
-		    fieldWidth: dimensions_grid.adjustedFieldWidth
+            fieldWidth: dimensions_grid.adjustedFieldWidth
       }
       // end: x-axis row 2
 
@@ -211,7 +213,7 @@ import "./" as Esci
             visible: difference_axis_grid.visible
             name: "difference_axis_breaks"
             placeholderText: "auto"
-			fieldWidth: dimensions_grid.adjustedFieldWidth
+            fieldWidth: dimensions_grid.adjustedFieldWidth
       }
 
         // these two "fill" the row with 5 elements if difference_axis_units_visible is false
@@ -269,14 +271,14 @@ import "./" as Esci
           ]
       }
 
-      Label { visible: data_grid.visible; text: qsTr("Spread"); enabled: from_raw.checked }
+      Label { visible: data_grid.visible; text: qsTr("Spread"); enabled: !is_summary }
       DoubleField
       {
           visible: data_grid.visible
           name: "data_spread"
           id: data_spread
           defaultValue: 0.25
-          enabled: from_raw.checked
+          enabled: !is_summary
           min: 0
           max: 5
           fieldWidth: dimensions_grid.adjustedFieldWidth
@@ -292,7 +294,7 @@ import "./" as Esci
           name: "error_nudge"
           id: error_nudge
           defaultValue: 0.3
-          enabled: from_raw.checked
+          enabled: !is_summary
           min: 0
           max: 5
         fieldWidth: dimensions_grid.adjustedFieldWidth

--- a/inst/qml/esci/RawOrSummary.qml
+++ b/inst/qml/esci/RawOrSummary.qml
@@ -1,0 +1,29 @@
+import QtQuick
+import QtQuick.Layouts
+import JASP.Controls
+import JASP
+
+RadioButtonGroup
+{
+      property bool is_summary: from_summary.checked
+
+      name: "switch"
+      columns: 2
+      Layout.columnSpan: parent.columns
+
+      RadioButton
+      {
+            value:      "from_raw";
+            label:      qsTr("Analyze full data");
+            checked:    dataSetInfo.dataAvailable;
+            enabled:    dataSetInfo.dataAvailable
+      }
+
+      RadioButton
+      {
+            id:         from_summary
+            value:      "from_summary";
+            label:      qsTr("Analyze summary data");
+            checked:    !dataSetInfo.dataAvailable
+      }
+}

--- a/inst/qml/esci/ScatterplotOptions.qml
+++ b/inst/qml/esci/ScatterplotOptions.qml
@@ -7,9 +7,11 @@ import "./" as Esci
 
   Section
   {
+    property bool is_summary: false
+
     title: qsTr("Scatterplot options")
-    enabled: from_raw.checked
-    visible: from_raw.checked
+    enabled: !is_summary
+    visible: !is_summary
 
     property alias sp_other_options_grid_enabled: sp_other_options_grid.enabled
     property alias sp_other_options_grid_visible: sp_other_options_grid.visible
@@ -334,16 +336,16 @@ import "./" as Esci
     	  {
     	    name: "show_mean_lines";
     	    label: qsTr("Cross through means of <i>X</i> and <i>Y</i>")
-    	    enabled: from_raw.checked
-          visible: from_raw.checked
+            enabled: !is_summary
+          visible: !is_summary
     	   }
 
     	  CheckBox
     	  {
     	    name: "plot_as_z";
     	    label: qsTr("<i>Z</i> scores rather than raw scores")
-    	    enabled: from_raw.checked
-          visible: from_raw.checked
+            enabled: !is_summary
+          visible: !is_summary
     	   }
 
         Label {
@@ -354,8 +356,8 @@ import "./" as Esci
     	  {
     	    name: "show_r";
     	    label: qsTr("<i>r</i> value on scatterplot")
-    	    enabled: from_raw.checked
-          visible: from_raw.checked
+            enabled: !is_summary
+          visible: !is_summary
     	   }
 
         Label {

--- a/inst/qml/jasp_describe.qml
+++ b/inst/qml/jasp_describe.qml
@@ -24,34 +24,34 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
+
+  columns: 1
 
   VariablesForm
-  	{
-  		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-  		AvailableVariablesList { name: "allVariablesList" }
-  		AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["scale"]; singleVariable: true}
-  	}
+  {
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["scale"]; singleVariable: true}
+  }
 
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  Layout.columnSpan: 2
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
 
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
-	}
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
+  }
 
-	Group
-	{
-	  title: qsTr("<b>Explore</b>")
+  Group
+  {
+    title: qsTr("<b>Explore</b>")
 
 
-	   GridLayout {
+    GridLayout {
       id: explore_grid
       columns: 3
 
@@ -61,14 +61,14 @@ Form
       }
 
       CheckBox {
-	      name: "mark_mean";
-	      label: qsTr("Mean")
-	    }
+        name: "mark_mean";
+        label: qsTr("Mean")
+      }
 
       CheckBox {
-	      name: "mark_median";
-	      label: qsTr("Median")
-	    }
+        name: "mark_median";
+        label: qsTr("Median")
+      }
 
 
       Label {
@@ -76,23 +76,23 @@ Form
       }
 
       CheckBox {
-	      name: "mark_sd";
-	      label: qsTr("Standard deviation")
-	    }
+        name: "mark_sd";
+        label: qsTr("Standard deviation")
+      }
 
       CheckBox {
-	      name: "mark_quartiles";
-	      label: qsTr("Quartiles")
-	    }
+        name: "mark_quartiles";
+        label: qsTr("Quartiles")
+      }
 
       Label {
         text: qsTr("<i>z</i> scores")
       }
 
       CheckBox {
-	      name: "mark_z_lines";
-	      label: qsTr("<i>z</i> lines")
-	    }
+        name: "mark_z_lines";
+        label: qsTr("<i>z</i> lines")
+      }
 
       Label {
         text: ""
@@ -104,17 +104,17 @@ Form
       }
 
       PercentField
-		  {
-		    name: "mark_percentile"
-		    label: qsTr("Highlight bottom")
-		    defaultValue: 0
-		  }
+      {
+        name: "mark_percentile"
+        label: qsTr("Highlight bottom")
+        defaultValue: 0
+      }
 
 
     }  // end explore grid
 
 
-	} // end explore
+  } // end explore
 
 
   Esci.ScatterplotOptions {
@@ -124,9 +124,10 @@ Form
     histogram_grid_visible: true
     sp_plot_width_defaultValue: 500
     sp_plot_height_defaultValue: 400
+  }
 
 
-    Section
+  Section
   {
     title: qsTr("Aesthetics")
 
@@ -178,15 +179,12 @@ Form
   } // end aesthetics
 
 
+  Esci.ConfLevel
+  {
+    name: "conf_level"
+    id: conf_level
+    enabled: false
+    visible: false
   }
-
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    enabled: false
-		    visible: false
-		  }
-
 
 }

--- a/inst/qml/jasp_estimate_mdiff_2x2.qml
+++ b/inst/qml/jasp_estimate_mdiff_2x2.qml
@@ -24,23 +24,22 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
+  columns: 1
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
   function switch_adjust() {
-      if (from_summary.checked | mixed.checked) {
-        effect_size.currentValue = "mean_difference";
-      }
+    if (switch_source.is_summary | mixed.checked) {
+      effect_size.currentValue = "mean_difference";
+    }
   }
 
 
   RadioButtonGroup {
     columns: 2
-    Layout.columnSpan: 2
     name: "design"
     id: design
 
@@ -56,60 +55,42 @@ Form
       label: qsTr("Mixed (RCT)");
       id: mixed
       onClicked: {
-         switch_adjust()
+        switch_adjust()
       }
     }
   }  // end design selection
 
 
-  RadioButtonGroup {
-    columns: 2
-    Layout.columnSpan: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
     visible: fully_between.checked
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-      onClicked: {
-         switch_adjust()
-      }
-    }
-  }  // end raw or summary
-
+    onValueChanged: switch_adjust()
+  }
 
   Section {
-    enabled: from_raw.checked & fully_between.checked
-    visible: from_raw.checked & fully_between.checked
-    expanded: from_raw.checked & fully_between.checked
+    enabled: !switch_source.is_summary & fully_between.checked
+    visible: !switch_source.is_summary& fully_between.checked
+    expanded: !switch_source.is_summary & fully_between.checked
     title: "Between subjects, full data"
 
-    	VariablesForm
-    	{
-    		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-    		AvailableVariablesList { name: "allVariablesList_between" }
-    		AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["scale"]; singleVariable: true }
-    		AssignedVariablesList { name: "grouping_variable_A"; title: qsTr("Grouping variable A"); allowedColumns: ["nominal"]; singleVariable: true }
-    		AssignedVariablesList { name: "grouping_variable_B"; title: qsTr("Grouping variable B"); allowedColumns: ["nominal"]; singleVariable: true }
+    VariablesForm
+    {
+      preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+      AvailableVariablesList { name: "allVariablesList_between" }
+      AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["scale"]; singleVariable: true }
+      AssignedVariablesList { name: "grouping_variable_A"; title: qsTr("Grouping variable A"); allowedColumns: ["nominal"]; singleVariable: true }
+      AssignedVariablesList { name: "grouping_variable_B"; title: qsTr("Grouping variable B"); allowedColumns: ["nominal"]; singleVariable: true }
 
-    	}
+    }
 
   }  // end between_raw
 
 
   Section {
-    enabled: from_summary.checked & fully_between.checked
-    visible: from_summary.checked & fully_between.checked
-    expanded: from_summary.checked & fully_between.checked
+    enabled: switch_source.is_summary & fully_between.checked
+    visible: switch_source.is_summary & fully_between.checked
+    expanded: switch_source.is_summary & fully_between.checked
     title: qsTr("Between subjects, summary data")
 
     GridLayout {
@@ -330,149 +311,147 @@ Form
 
     TextField
     {
-        name: "outcome_variable_name_bs"
-        label: qsTr("Outcome variable name")
-        placeholderText: qsTr("My outcome variable")
-        Layout.columnSpan: 2
+      name: "outcome_variable_name_bs"
+      label: qsTr("Outcome variable name")
+      placeholderText: qsTr("My outcome variable")
+      Layout.columnSpan: 2
     }
 
 
-      CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
+    }
 
   }  // fully between summary section
 
 
-    Section {
+  Section {
     enabled: mixed.checked
     visible: mixed.checked
     expanded: mixed.checked
     title: qsTr("RCT, full data")
 
-    	VariablesForm
-    	{
-    		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-    		AvailableVariablesList { name: "allVariablesList" }
-    		AssignedVariablesList { name: "outcome_variable_level1"; title: qsTr("First repeated measure"); allowedColumns: ["scale"]; singleVariable: true }
-    		AssignedVariablesList { name: "outcome_variable_level2"; title: qsTr("Second repeated measure"); allowedColumns: ["scale"]; singleVariable: true }
-    		AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal"]; singleVariable: true }
-    	}
+    VariablesForm
+    {
+      preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+      AvailableVariablesList { name: "allVariablesList" }
+      AssignedVariablesList { name: "outcome_variable_level1"; title: qsTr("First repeated measure"); allowedColumns: ["scale"]; singleVariable: true }
+      AssignedVariablesList { name: "outcome_variable_level2"; title: qsTr("Second repeated measure"); allowedColumns: ["scale"]; singleVariable: true }
+      AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal"]; singleVariable: true }
+    }
 
 
-    	TextField
-      {
-        name: "repeated_measures_name"
-        label: qsTr("Repeated measure name")
-        placeholderText: qsTr("Time")
-        Layout.columnSpan: 2
-      }
+    TextField
+    {
+      name: "repeated_measures_name"
+      label: qsTr("Repeated measure name")
+      placeholderText: qsTr("Time")
+      Layout.columnSpan: 2
+    }
 
 
-    	TextField
-      {
-        name: "outcome_variable_name"
-        label: qsTr("Outcome variable name")
-        placeholderText: qsTr("My outcome variable")
-        Layout.columnSpan: 2
-      }
+    TextField
+    {
+      name: "outcome_variable_name"
+      label: qsTr("Outcome variable name")
+      placeholderText: qsTr("My outcome variable")
+      Layout.columnSpan: 2
+    }
 
 
   } // mixed variable selection
 
 
-	Group
-	{
-		title: qsTr("<b>Between-subjects analysis options</b>")
-		Layout.columnSpan: 2
-		visible: fully_between.checked
+  Group
+  {
+    title: qsTr("<b>Between-subjects analysis options</b>")
+    visible: fully_between.checked
 
-		DropDown
-      {
-        name: "effect_size"
-        label: qsTr("Effect size of interest")
-        enabled: from_raw.checked & fully_between.checked
-        values:
+    DropDown
+    {
+      name: "effect_size"
+      label: qsTr("Effect size of interest")
+      enabled: !switch_source.is_summary & fully_between.checked
+      values:
           [
-            { label: qsTr("Mean difference"), value: "mean_difference"},
-            { label: qsTr("Median difference"), value: "median_difference"}
-          ]
-        id: effect_size
-      }
+        { label: qsTr("Mean difference"), value: "mean_difference"},
+        { label: qsTr("Median difference"), value: "median_difference"}
+      ]
+      id: effect_size
+    }
 
     CheckBox {
-	    name: "assume_equal_variance";
-	    id: assume_equal_variance
-	    label: qsTr("Assume equal variances")
-	    checked: true
-	    enabled: effect_size.currentValue == "mean_difference"
-    }
-
-	}
-
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-	}
-
-
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
-	  CheckBox
-	  {
-	    name: "show_interaction_plot";
-	    id: show_interaction_plot
-	    label: qsTr("Figure to emphasize interaction");
-	   }
-
-	  CheckBox {
-	    name: "show_CI";
-	    id: show_CI
-	    label: qsTr("CI for each simple effect")
-	    enabled: show_interaction_plot.checked
-    }
-	}
-
-
-  Esci.FigureOptions {
-   simple_labels_enabled: fully_between.checked
-   width_defaultValue: 700
-   height_defaultValue: 400
-   error_nudge_defaultValue: 0.5
-   data_spread_defaultValue: 0.2
-   error_scale_defaultValue: 0.25
-
-     Esci.AestheticsAll {
-
+      name: "assume_equal_variance";
+      id: assume_equal_variance
+      label: qsTr("Assume equal variances")
+      checked: true
+      enabled: effect_size.currentValue == "mean_difference"
     }
 
   }
 
-	Esci.HeOptions {
-	  id: myHeOptions
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
+
+  }
+
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
+    CheckBox
+    {
+      name: "show_interaction_plot";
+      id: show_interaction_plot
+      label: qsTr("Figure to emphasize interaction");
+    }
+
+    CheckBox {
+      name: "show_CI";
+      id: show_CI
+      label: qsTr("CI for each simple effect")
+      enabled: show_interaction_plot.checked
+    }
+  }
+
+
+  Esci.FigureOptions {
+    is_summary: switch_source.is_summary
+    simple_labels_enabled: fully_between.checked
+    width_defaultValue: 700
+    height_defaultValue: 400
+    error_nudge_defaultValue: 0.5
+    data_spread_defaultValue: 0.2
+    error_scale_defaultValue: 0.25
+  }
+
+  Esci.AestheticsAll {
+    is_summary: switch_source.is_summary
+    is_mixed: mixed.checked
+  }
+
+  Esci.HeOptions {
+    id: myHeOptions
     null_value_enabled: false
     rope_units_visible: evaluate_hypotheses_checked
-     hgrid_columns: 4
+    hgrid_columns: 4
   }
 
 }

--- a/inst/qml/jasp_estimate_mdiff_ind_contrast.qml
+++ b/inst/qml/jasp_estimate_mdiff_ind_contrast.qml
@@ -24,252 +24,218 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
 
+  columns: 1
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
   function switch_adjust() {
-      if (from_summary.checked) {
-        effect_size.currentValue = "mean_difference";
-        show_ratio.checked = false;
-      }
+    if (switch_source.is_summary) {
+      effect_size.currentValue = "mean_difference";
+      show_ratio.checked = false;
+    }
   }
 
 
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
+    onValueChanged: switch_adjust()
+  }
 
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
+
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList {
+      name: "outcome_variable";
+      title: qsTr("Outcome variable(s)");
+      allowedColumns: ["scale"];
+
     }
+    AssignedVariablesList {
+      name: "grouping_variable";
+      title: qsTr("Grouping variable");
+      allowedColumns: ["nominal"];
+      singleVariable: trueOn
+    }
+  }
 
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-      onClicked: {
-         switch_adjust()
+  VariablesForm {
+    visible: switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList_summary" }
+    AssignedVariablesList {
+      name: "grouping_variable_levels";
+      id: grouping_variable_levels;
+      title: qsTr("Grouping variable levels");
+      allowedColumns: ["nominal"];
+      singleVariable: true;
+      onCountChanged: {
+        if (grouping_variable_levels.count > 0) summary_dirty.checked = true
+      }
+    }
+    AssignedVariablesList {
+      name: "means";
+      id: means;
+      title: qsTr("Group means");
+      allowedColumns: ["scale"];
+      singleVariable: true;
+      onCountChanged: {
+        if (means.count > 0) summary_dirty.checked = true
+      }
+    }
+    AssignedVariablesList {
+      name: "sds";
+      id: sds;
+      title: qsTr("Group standard deviations");
+      allowedColumns: ["scale"];
+      singleVariable: true;
+      onCountChanged: {
+        if (sds.count > 0) summary_dirty.checked = true
+      }
+    }
+    AssignedVariablesList {
+      name: "ns";
+      id: ns;
+      title: qsTr("Group sample sizes");
+      allowedColumns: ["scale"];
+      singleVariable: true;
+      onCountChanged: {
+        if (ns.count > 0) summary_dirty.checked = true
       }
     }
   }
 
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
+
+  Group {
+    visible: switch_source.is_summary
+
+    TextField
+    {
+      name: "outcome_variable_name"
+      label: qsTr("Outcome variable name")
+      placeholderText: "Outcome variable"
+    }
 
 
-    	VariablesForm
-    	{
-    		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-    		AvailableVariablesList { name: "allVariablesList" }
-    		AssignedVariablesList {
-    		  name: "outcome_variable";
-    		  title: qsTr("Outcome variable(s)");
-    		  allowedColumns: ["scale"];
-
-    		}
-    		AssignedVariablesList {
-    		  name: "grouping_variable";
-    		  title: qsTr("Grouping variable");
-    		  allowedColumns: ["nominal"];
-    		  singleVariable: trueOn
-    		}
-    	}
-
-
+    TextField
+    {
+      name: "grouping_variable_name"
+      label: qsTr("Grouping variable name")
+      placeholderText: "Grouping variable"
+    }
 
   }
 
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
-
-
-    VariablesForm {
-      preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-      AvailableVariablesList { name: "allVariablesList_summary" }
-      AssignedVariablesList {
-        name: "grouping_variable_levels";
-        id: grouping_variable_levels;
-        title: qsTr("Grouping variable levels");
-        allowedColumns: ["nominal"];
-        singleVariable: true;
-    		  onCountChanged: {
-    		    if (grouping_variable_levels.count > 0) summary_dirty.checked = true
-          }
-      }
-      AssignedVariablesList {
-        name: "means";
-        id: means;
-        title: qsTr("Group means");
-        allowedColumns: ["scale"];
-        singleVariable: true;
-          onCountChanged: {
-    		    if (means.count > 0) summary_dirty.checked = true
-          }
-      }
-      AssignedVariablesList {
-        name: "sds";
-        id: sds;
-        title: qsTr("Group standard deviations");
-        allowedColumns: ["scale"];
-        singleVariable: true;
-          onCountChanged: {
-    		    if (sds.count > 0) summary_dirty.checked = true
-          }
-      }
-      AssignedVariablesList {
-        name: "ns";
-        id: ns;
-        title: qsTr("Group sample sizes");
-        allowedColumns: ["scale"];
-        singleVariable: true;
-          onCountChanged: {
-    		    if (ns.count > 0) summary_dirty.checked = true
-          }
-      }
-    }
-
-
-    Group {
-      Layout.columnSpan: 2
-      TextField
-      {
-        name: "outcome_variable_name"
-        label: qsTr("Outcome variable name")
-        placeholderText: "Outcome variable"
-      }
-
-
-      TextField
-      {
-        name: "grouping_variable_name"
-        label: qsTr("Grouping variable name")
-        placeholderText: "Grouping variable"
-      }
-
-    }
-
-
-    	CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      checked: false
-	      visible: false
-	    }
+  CheckBox
+  {
+    name: "summary_dirty";
+    id: summary_dirty
+    checked: false
+    visible: false
   }
 
   Group {
     title: qsTr("<b>Define contrast</b>")
-    Layout.columnSpan: 2
 
-     TextField
-      {
-        name: "reference_labels"
-        id: reference_labels
-        label: qsTr("Reference subset")
-        fieldWidth: 400
-      }
+    TextField
+    {
+      name: "reference_labels"
+      id: reference_labels
+      label: qsTr("Reference subset")
+      fieldWidth: 400
+    }
 
-     TextField
-      {
-        name: "comparison_labels"
-        id: comparison_labels
-        label: qsTr("Comparison subset")
-        fieldWidth: 400
-      }
+    TextField
+    {
+      name: "comparison_labels"
+      id: comparison_labels
+      label: qsTr("Comparison subset")
+      fieldWidth: 400
+    }
 
 
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
 
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-		DropDown
-      {
-        name: "effect_size"
-        label: qsTr("Effect size of interest")
-        enabled: from_raw.checked
-        values:
-          [
-            { label: "Mean difference", value: "mean_difference"},
-            { label: "Median difference", value: "median_difference"}
-          ]
-        id: effect_size
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
       }
-
-    CheckBox {
-	    name: "assume_equal_variance";
-	    id: assume_equal_variance
-	    label: qsTr("Assume equal variances")
-	    checked: true
-	    enabled: effect_size.currentValue == "mean_difference"
     }
 
-	}
+    DropDown
+    {
+      name: "effect_size"
+      label: qsTr("Effect size of interest")
+      enabled: !switch_source.is_summary
+      values:
+          [
+        { label: "Mean difference", value: "mean_difference"},
+        { label: "Median difference", value: "median_difference"}
+      ]
+      id: effect_size
+    }
 
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
+    CheckBox {
+      name: "assume_equal_variance";
+      id: assume_equal_variance
+      label: qsTr("Assume equal variances")
+      checked: true
+      enabled: effect_size.currentValue == "mean_difference"
+    }
 
-	  CheckBox
-	  {
-	    name: "mixed";
-	    id: mixed
-	    visible: false
-	    enabled: false
-	   }
-	}
+  }
+
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
+
+    CheckBox
+    {
+      name: "mixed";
+      id: mixed
+      visible: false
+      enabled: false
+    }
+  }
 
 
   Esci.FigureOptions {
-   simple_labels_enabled: true
-   width_defaultValue: 550
-   height_defaultValue: 450
-   error_nudge_defaultValue: 0.5
-   data_spread_defaultValue: 0.20
-   error_scale_defaultValue: 0.25
-
-
-    Esci.AestheticsAll {
-
-    }
+    is_summary: switch_source.is_summary
+    simple_labels_enabled: true
+    width_defaultValue: 550
+    height_defaultValue: 450
+    error_nudge_defaultValue: 0.5
+    data_spread_defaultValue: 0.20
+    error_scale_defaultValue: 0.25
   }
 
 
+  Esci.AestheticsAll {
+    is_summary: switch_source.is_summary
+  }
 
-
-	Esci.HeOptions {
-	  id: myHeOptions
+  Esci.HeOptions {
+    id: myHeOptions
     null_value_enabled: false
     rope_units_visible: evaluate_hypotheses_checked
     hgrid_columns: 4

--- a/inst/qml/jasp_estimate_mdiff_one.qml
+++ b/inst/qml/jasp_estimate_mdiff_one.qml
@@ -24,192 +24,160 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  columns: 1
+
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
   function switch_adjust() {
-      if (from_summary.checked) {
-        effect_size.currentValue = "mean"
-      }
+    if (switch_source.is_summary) {
+      effect_size.currentValue = "mean"
+    }
   }
 
-
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-      onClicked: {
-         switch_adjust()
-      }
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-      onClicked: {
-         switch_adjust()
-      }
-    }
+    onValueChanged: switch_adjust()
   }
 
 
-
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-  	VariablesForm
-  	{
-  		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-  		AvailableVariablesList { name: "allVariablesList" }
-  		AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["scale"] }
-  	}
-
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["scale"] }
   }
 
+  GridLayout {
+    id: summary_grid
+    columns: 2
+    rowSpacing: 1
+    columnSpacing: 1
+    visible: switch_source.is_summary
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
+    Label {
+      text: qsTr("Mean (<i>M</i>)")
+    }
 
-    GridLayout {
-      id: summary_grid
-      columns: 2
-      rowSpacing: 1
-      columnSpacing: 1
-
-
-      Label {
-        text: qsTr("Mean (<i>M</i>)")
+    DoubleField
+    {
+      name: "mean"
+      defaultValue: 10.1
+      fieldWidth: jaspTheme.textFieldWidth
+      negativeValues: true
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      DoubleField
-      {
-        name: "mean"
-        defaultValue: 10.1
-        fieldWidth: jaspTheme.textFieldWidth
-        negativeValues: true
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
+    Label {
+      text: qsTr("Standard deviation (<i>s</i>)")
+    }
+
+    DoubleField
+    {
+      name: "sd"
+      defaultValue: 3
+      min: 0
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      Label {
-        text: qsTr("Standard deviation (<i>s</i>)")
+    Label {
+      text: qsTr("Sample size (<i>N</i>)")
+    }
+
+    IntegerField
+    {
+      name: "n"
+      defaultValue: 20
+      min: 2
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      DoubleField
-      {
-        name: "sd"
-        defaultValue: 3
-        min: 0
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
+    Label {
+      text: qsTr("Outcome variable name")
+    }
 
-      Label {
-        text: qsTr("Sample size (<i>N</i>)")
-      }
-
-      IntegerField
-      {
-        name: "n"
-        defaultValue: 20
-        min: 2
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-      Label {
-        text: qsTr("Outcome variable name")
-      }
-
-      TextField
-      {
-        name: "outcome_variable_name"
-        placeholderText: qsTr("Outcome variable")
-      }
+    TextField
+    {
+      name: "outcome_variable_name"
+      placeholderText: qsTr("Outcome variable")
+    }
 
 
-      CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
-
-
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
     }
 
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-		DropDown
-      {
-        name: "effect_size"
-        label: qsTr("Effect size of interest")
-        values:
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
+    DropDown
+    {
+      name: "effect_size"
+      label: qsTr("Effect size of interest")
+      values:
           [
-            { label: qsTr("Mean"), value: "mean"},
-            { label: qsTr("Median"), value: "median"}
-          ]
-        id: effect_size
-        enabled: from_raw.checked
-      }
+        { label: qsTr("Mean"), value: "mean"},
+        { label: qsTr("Median"), value: "median"}
+      ]
+      id: effect_size
+      enabled: !switch_source.is_summary
+    }
 
-	}
+  }
 
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
-	  CheckBox
-	  {
-	    name: "show_calculations";
-	    label: qsTr("Calculation components");
-	    enabled: effect_size.currentValue == "mean"
-	   }
-	}
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
+    CheckBox
+    {
+      name: "show_calculations";
+      label: qsTr("Calculation components");
+      enabled: effect_size.currentValue == "mean"
+    }
+  }
 
 
   Esci.FigureOptions {
+    is_summary: switch_source.is_summary
     simple_labels_enabled: false
     simple_labels_visible: false
     difference_axis_grid_visible: false
+  }
 
-        Section
+  Section
   {
     title: qsTr("Aesthetics")
 
@@ -221,9 +189,9 @@ Form
 
     GridLayout
     {
-    columns: 5
-    rowSpacing:    jaspTheme.rowGroupSpacing
-    columnSpacing: jaspTheme.columnGroupSpacing
+      columns: 5
+      rowSpacing:    jaspTheme.rowGroupSpacing
+      columnSpacing: jaspTheme.columnGroupSpacing
 
       Label { text: "<b>CI</b>" }
 
@@ -302,7 +270,7 @@ Form
       {
         name: "shape_raw"
         id: shape_raw
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         fieldWidth: jaspTheme.textFieldWidth * 0.7
       }
 
@@ -312,7 +280,7 @@ Form
       {
         name: "size_raw"
         defaultValue: 2
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         fieldWidth: jaspTheme.textFieldWidth * 0.7
       }
 
@@ -325,7 +293,7 @@ Form
         name: "color_raw"
         startValue: '#008DF9'
         id: color_raw
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         fieldWidth: jaspTheme.textFieldWidth * 0.7
       }
 
@@ -336,7 +304,7 @@ Form
         name: "fill_raw"
         startValue: 'NA'
         id: fill_raw
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         fieldWidth: jaspTheme.textFieldWidth * 0.7
       }
 
@@ -348,17 +316,13 @@ Form
       Esci.AlphaSelect
       {
         name: "alpha_raw"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         fieldWidth: jaspTheme.textFieldWidth * 0.7
       }
 
     }
 
   } // end aesthetics
-
-
-  }
-
 
 
   Esci.HeOptions {

--- a/inst/qml/jasp_estimate_mdiff_paired.qml
+++ b/inst/qml/jasp_estimate_mdiff_paired.qml
@@ -24,328 +24,301 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
 
-	property alias sdiff_text: sdiff.text
-	property alias conf_level_value: conf_level.value
+  columns: 1
+
+  property alias sdiff_text: sdiff.text
+  property alias conf_level_value: conf_level.value
 
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
   function switch_adjust() {
-      if (from_summary.checked) {
-        effect_size.currentValue = "mean_difference";
-        show_ratio.checked = false;
-      }
+    if (from_summary.is_summary) {
+      effect_size.currentValue = "mean_difference";
+      show_ratio.checked = false;
+    }
   }
 
   function sdiff_adjust() {
-      sdiff.value = ((sd1.value**2 + sd2.value**2 - 2*r.value*sd1.value*sd2.value)**0.5).toFixed(2);
+    sdiff.value = ((sd1.value**2 + sd2.value**2 - 2*r.value*sd1.value*sd2.value)**0.5).toFixed(2);
   }
 
   function r_adjust() {
-      r.value = ((sdiff.value**2 - sd1.value**2 - sd2.value**2)/(-2*sd1.value*sd2.value)).toFixed(2);
+    r.value = ((sdiff.value**2 - sd1.value**2 - sd2.value**2)/(-2*sd1.value*sd2.value)).toFixed(2);
   }
 
 
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
+    onValueChanged: switch_adjust()
+  }
 
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
+
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "reference_measure"; title: qsTr("Reference variable"); allowedColumns: ["scale"]; singleVariable: true }
+    AssignedVariablesList { name: "comparison_measure"; title: qsTr("Comparison variable"); allowedColumns: ["scale"]; singleVariable: true }
+  }
+
+  GridLayout {
+    id: summary_grid
+    visible: switch_source.is_summary
+    columns: 3
+    rowSpacing: 1
+    columnSpacing: 1
+
+    Item {}
+
+    Label {
+      text: qsTr("Reference group")
     }
 
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-      onClicked: {
-         switch_adjust()
+    Label {
+      text: qsTr("Comparison group")
+    }
+
+
+    Label {
+      text: qsTr("Name")
+    }
+
+    TextField
+    {
+      name: "reference_measure_name"
+      placeholderText: qsTr("Reference measure")
+    }
+
+    TextField
+    {
+      name: "comparison_measure_name"
+      placeholderText: qsTr("Comparison measure")
+    }
+
+    Label {
+      text: qsTr("Mean (<i>M</i>)")
+    }
+
+    DoubleField
+    {
+      name: "reference_mean"
+      defaultValue: 10
+      negativeValues: true
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
     }
-  }
 
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-
-    	VariablesForm
-    	{
-    		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-    		AvailableVariablesList { name: "allVariablesList" }
-    		AssignedVariablesList { name: "reference_measure"; title: qsTr("Reference variable"); allowedColumns: ["scale"]; singleVariable: true }
-    		AssignedVariablesList { name: "comparison_measure"; title: qsTr("Comparison variable"); allowedColumns: ["scale"]; singleVariable: true }
-    	}
-
-  }
-
-
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
-
-    GridLayout {
-      id: summary_grid
-      columns: 3
-      rowSpacing: 1
-      columnSpacing: 1
-
-      Item {}
-
-      Label {
-        text: qsTr("Reference group")
+    DoubleField
+    {
+      name: "comparison_mean"
+      defaultValue: 12
+      negativeValues: true
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      Label {
-        text: qsTr("Comparison group")
+
+    Label {
+      text: qsTr("Standard deviation (<i>s</i>)")
+    }
+
+    DoubleField
+    {
+      name: "reference_sd"
+      id: sd1
+      defaultValue: 2.1
+      min: 0
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-
-      Label {
-        text: qsTr("Name")
+    DoubleField
+    {
+      name: "comparison_sd"
+      id: sd2
+      defaultValue: 2.2
+      min: 0
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      TextField
-      {
-        name: "reference_measure_name"
-        placeholderText: qsTr("Reference measure")
+    Label {
+      text: qsTr("Sample size (<i>N</i>)")
+    }
+
+    IntegerField
+    {
+      name: "n"
+      defaultValue: 20
+      Layout.columnSpan: 2
+      min: 2
+      fieldWidth: jaspTheme.textFieldWidth * 2
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      TextField
-      {
-        name: "comparison_measure_name"
-        placeholderText: qsTr("Comparison measure")
-      }
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
+    }
 
-      Label {
-        text: qsTr("Mean (<i>M</i>)")
-      }
 
-      DoubleField
-      {
-        name: "reference_mean"
-        defaultValue: 10
-        negativeValues: true
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
+    RadioButtonGroup {
+      Layout.columnSpan: 3
+      columns: 2
+      name: "enter_r_or_sdiff"
+      id: enter_r_or_sdiff
+
+      RadioButton {
+        value: "enter_r";
+        label: qsTr("Enter <i>r</i>");
+        checked: true;
+        id: enter_r
+        onClicked: {
+          sdiff_adjust()
         }
       }
 
-      DoubleField
-      {
-        name: "comparison_mean"
-        defaultValue: 12
-        negativeValues: true
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
+      RadioButton {
+        value: "enter_sdiff";
+        id: enter_sdiff
+        label: qsTr("Enter standard deviation of difference scores (<i>s</i><sub>diff</sub>)")
+        onClicked: {
+          r_adjust()
         }
       }
+    }
 
 
-      Label {
-        text: qsTr("Standard deviation (<i>s</i>)")
+    Label {
+      text: qsTr("Correlation (<i>r</i>)")
+    }
+
+    DoubleField
+    {
+      name: "correlation"
+      id: r
+      Layout.columnSpan: 2
+      enabled: enter_r.checked
+      min: -1
+      max: 1
+      defaultValue: 0.7
+      fieldWidth: jaspTheme.textFieldWidth
+      onFocusChanged: {
+        sdiff_adjust()
       }
-
-      DoubleField
-      {
-        name: "reference_sd"
-        id: sd1
-        defaultValue: 2.1
-        min: 0
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      DoubleField
-      {
-        name: "comparison_sd"
-        id: sd2
-        defaultValue: 2.2
-        min: 0
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
+
+    Label {
+      textFormat: Text.RichText
+      text: qsTr("Standard deviation of difference scores (<i>s</i><sub>diff</sub>)")
+    }
+
+    DoubleField
+    {
+      name: "sdiff"
+      id: sdiff
+      enabled: enter_sdiff.checked
+      Layout.columnSpan: 2
+      defaultValue: 1.67
+      fieldWidth: jaspTheme.textFieldWidth
+      onFocusChanged: {
+        r_adjust()
       }
-
-      Label {
-        text: qsTr("Sample size (<i>N</i>)")
+      onEditingFinished : {
+        summary_dirty.checked = true
       }
+    }
 
-      IntegerField
-      {
-        name: "n"
-        defaultValue: 20
-        Layout.columnSpan: 2
-        min: 2
-        fieldWidth: jaspTheme.textFieldWidth * 2
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
+
+  } // end first summary data grid
+
+
+
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
       }
+    }
 
-      CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
-
-
-      RadioButtonGroup {
-        Layout.columnSpan: 3
-        columns: 2
-        name: "enter_r_or_sdiff"
-        id: enter_r_or_sdiff
-
-        RadioButton {
-          value: "enter_r";
-          label: qsTr("Enter <i>r</i>");
-          checked: true;
-          id: enter_r
-          onClicked: {
-            sdiff_adjust()
-          }
-        }
-
-        RadioButton {
-          value: "enter_sdiff";
-          id: enter_sdiff
-          label: qsTr("Enter standard deviation of difference scores (<i>s</i><sub>diff</sub>)")
-          onClicked: {
-            r_adjust()
-          }
-        }
-      }
-
-
-      Label {
-        text: qsTr("Correlation (<i>r</i>)")
-      }
-
-      DoubleField
-      {
-        name: "correlation"
-        id: r
-        Layout.columnSpan: 2
-        enabled: enter_r.checked
-        min: -1
-        max: 1
-        defaultValue: 0.7
-        fieldWidth: jaspTheme.textFieldWidth
-          onFocusChanged: {
-            sdiff_adjust()
-          }
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-
-      Label {
-        textFormat: Text.RichText
-        text: qsTr("Standard deviation of difference scores (<i>s</i><sub>diff</sub>)")
-      }
-
-      DoubleField
-      {
-        name: "sdiff"
-        id: sdiff
-        enabled: enter_sdiff.checked
-        Layout.columnSpan: 2
-        defaultValue: 1.67
-        fieldWidth: jaspTheme.textFieldWidth
-          onFocusChanged: {
-            r_adjust()
-          }
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-
-    } // end first summary data grid
-
-
-
-  }
-
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-		DropDown
-      {
-        name: "effect_size"
-        label: qsTr("Effect size of interest")
-        enabled: from_raw.checked
-        values:
+    DropDown
+    {
+      name: "effect_size"
+      label: qsTr("Effect size of interest")
+      enabled: !switch_source.is_summary
+      values:
           [
-            { label: qsTr("Mean difference"), value: "mean_difference"},
-            { label: qsTr("Median difference"), value: "median_difference"}
-          ]
-        id: effect_size
-      }
-
-	}
-
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
-	  CheckBox
-	  {
-	    name: "show_calculations";
-	    label: qsTr("Calculation components");
-	    enabled: effect_size.currentValue == "mean_difference"
-	   }
-	  CheckBox {
-	    name: "show_ratio";
-	    id: show_ratio
-	    label: qsTr("Ratio between groups (appropriate only for true ratio scales")
-	    enabled: from_raw.checked
+        { label: qsTr("Mean difference"), value: "mean_difference"},
+        { label: qsTr("Median difference"), value: "median_difference"}
+      ]
+      id: effect_size
     }
-	}
+
+  }
+
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
+    CheckBox
+    {
+      name: "show_calculations";
+      label: qsTr("Calculation components");
+      enabled: effect_size.currentValue == "mean_difference"
+    }
+    CheckBox {
+      name: "show_ratio";
+      id: show_ratio
+      label: qsTr("Ratio between groups (appropriate only for true ratio scales")
+      enabled: !switch_source.is_summary
+    }
+  }
 
 
   Esci.FigureOptions {
+    is_summary: switch_source.is_summary
     width_defaultValue: 600
     height_defaultValue: 400
     error_nudge_defaultValue: 0.5
     data_spread_defaultValue: 0.2
     error_scale_defaultValue: 0.25
+  }
 
 
-        Section
+  Section
   {
     title: qsTr("Aesthetics")
 
@@ -745,7 +718,7 @@ Form
         name: "shape_raw_reference"
         id: shape_raw_reference
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ShapeSelect
@@ -753,7 +726,7 @@ Form
         name: "shape_raw_comparison"
         id: shape_raw_comparison
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ShapeSelect
@@ -761,7 +734,7 @@ Form
         name: "shape_raw_difference"
         id: shape_raw_difference
         startValue: 'triangle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -774,7 +747,7 @@ Form
         name: "size_raw_reference"
         id: size_raw_reference
         defaultValue: 2
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -783,7 +756,7 @@ Form
         name: "size_raw_comparison"
         id: size_raw_comparison
         defaultValue: 2
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -792,7 +765,7 @@ Form
         name: "size_raw_difference"
         id: size_raw_difference
         defaultValue: 2
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -805,7 +778,7 @@ Form
         name: "color_raw_reference"
         id: color_raw_reference
         startValue: "#008DF9"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -813,7 +786,7 @@ Form
         name: "color_raw_comparison"
         id: color_raw_comparison
         startValue: "#008DF9"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -821,7 +794,7 @@ Form
         name: "color_raw_difference"
         id: color_raw_difference
         startValue: "#E20134"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -834,7 +807,7 @@ Form
         name: "fill_raw_reference"
         id: fill_raw_reference
         startValue: "NA"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -842,7 +815,7 @@ Form
         name: "fill_raw_comparison"
         id: fill_raw_comparison
         startValue: "NA"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -850,7 +823,7 @@ Form
         name: "fill_raw_difference"
         id: fill_raw_difference
         startValue: "NA"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -862,7 +835,7 @@ Form
       {
         name: "alpha_raw_reference"
         id: alpha_raw_reference
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -870,7 +843,7 @@ Form
       {
         name: "alpha_raw_comparison"
         id: alpha_raw_comparison
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -878,7 +851,7 @@ Form
       {
         name: "alpha_raw_difference"
         id: alpha_raw_difference
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -889,9 +862,7 @@ Form
   } // end aesthetics
 
 
-  }
-
-	Esci.HeOptions {
+  Esci.HeOptions {
     id: myHeOptions
     null_value_enabled: false
     hgrid_columns: 4

--- a/inst/qml/jasp_estimate_mdiff_two.qml
+++ b/inst/qml/jasp_estimate_mdiff_two.qml
@@ -24,283 +24,251 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  columns: 1
+
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
   function switch_adjust() {
-      if (from_summary.checked) {
-        effect_size.currentValue = "mean_difference";
-        show_ratio.checked = false;
-      }
+    if (switch_source.is_summary) {
+      effect_size.currentValue = "mean_difference";
+      show_ratio.checked = false;
+    }
   }
 
-
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-      onClicked: {
-         switch_adjust()
-      }
-    }
+    onValueChanged: switch_adjust()
   }
 
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-
-    	VariablesForm
-    	{
-    		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-    		AvailableVariablesList { name: "allVariablesList" }
-    		AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable(s)"); allowedColumns: ["scale"] }
-    		AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal"]; singleVariable: true }
-    	}
-
-      Group {
-      	columns: 2
-    		Layout.columnSpan: 2
-
-      	CheckBox {
-      	  name: "switch_comparison_order";
-      	  label: qsTr("Switch comparison order")
-        }
-      }
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable(s)"); allowedColumns: ["scale"] }
+    AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal"]; singleVariable: true }
   }
 
+  CheckBox {
+    visible: !switch_source.is_summary
+    name: "switch_comparison_order";
+    label: qsTr("Switch comparison order")
+  }
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
+  GridLayout {
+    id: summary_grid
+    visible: switch_source.is_summary
+    columns: 3
+    rowSpacing: 1
+    columnSpacing: 1
 
-    GridLayout {
-      id: summary_grid
-      columns: 3
-      rowSpacing: 1
-      columnSpacing: 1
+    Item {}
 
-      Item {}
+    Label {
+      text: qsTr("Reference group")
+    }
 
-      Label {
-        text: qsTr("Reference group")
-      }
-
-      Label {
-        text: qsTr("Comparison group")
-      }
-
-
-      Item {}
-
-
-      TextField
-      {
-        name: "reference_level_name"
-        placeholderText: qsTr("Reference group")
-      }
-
-      TextField
-      {
-        name: "comparison_level_name"
-        placeholderText: qsTr("Comparison group")
-      }
-
-      Label {
-        text: qsTr("Mean (<i>M</i>)")
-        width: 900
-
-      }
-
-      DoubleField
-      {
-        name: "reference_mean"
-        defaultValue: 10
-        negativeValues: true
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-      DoubleField
-      {
-        name: "comparison_mean"
-        defaultValue: 12
-        negativeValues: true
-        fieldWidth: jaspTheme.textFieldWidth
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-
-      Label {
-        text: qsTr("Standard deviation (<i>s</i>)")
-        width: 400
-      }
-
-      DoubleField
-      {
-        name: "reference_sd"
-        defaultValue: 3
-        fieldWidth: jaspTheme.textFieldWidth
-        min: 0
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-      DoubleField
-      {
-        name: "comparison_sd"
-        defaultValue: 3
-        fieldWidth: jaspTheme.textFieldWidth
-        min: 0
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-
-      Label {
-        text: qsTr("Sample size (<i>n</i>)")
-        width: 400
-      }
-
-      IntegerField
-      {
-        name: "reference_n"
-        defaultValue: 20
-        fieldWidth: jaspTheme.textFieldWidth
-        min: 2
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
-      IntegerField
-      {
-        name: "comparison_n"
-        defaultValue: 20
-        fieldWidth: jaspTheme.textFieldWidth
-        min: 2
-        onEditingFinished : {
-          summary_dirty.checked = true
-        }
-      }
-
+    Label {
+      text: qsTr("Comparison group")
     }
 
 
-    Group {
-      Layout.columnSpan: 2
-      TextField
-      {
-        name: "outcome_variable_name"
-        label: qsTr("Outcome variable name")
-        placeholderText: qsTr("Outcome variable")
-      }
+    Item {}
 
 
-      TextField
-      {
-        name: "grouping_variable_name"
-        label: qsTr("Grouping variable name")
-        placeholderText: qsTr("Grouping variable")
-      }
+    TextField
+    {
+      name: "reference_level_name"
+      placeholderText: qsTr("Reference group")
+    }
+
+    TextField
+    {
+      name: "comparison_level_name"
+      placeholderText: qsTr("Comparison group")
+    }
+
+    Label {
+      text: qsTr("Mean (<i>M</i>)")
+      width: 900
 
     }
 
-      CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
+    DoubleField
+    {
+      name: "reference_mean"
+      defaultValue: 10
+      negativeValues: true
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
+      }
+    }
+
+    DoubleField
+    {
+      name: "comparison_mean"
+      defaultValue: 12
+      negativeValues: true
+      fieldWidth: jaspTheme.textFieldWidth
+      onEditingFinished : {
+        summary_dirty.checked = true
+      }
+    }
+
+
+    Label {
+      text: qsTr("Standard deviation (<i>s</i>)")
+      width: 400
+    }
+
+    DoubleField
+    {
+      name: "reference_sd"
+      defaultValue: 3
+      fieldWidth: jaspTheme.textFieldWidth
+      min: 0
+      onEditingFinished : {
+        summary_dirty.checked = true
+      }
+    }
+
+    DoubleField
+    {
+      name: "comparison_sd"
+      defaultValue: 3
+      fieldWidth: jaspTheme.textFieldWidth
+      min: 0
+      onEditingFinished : {
+        summary_dirty.checked = true
+      }
+    }
+
+
+    Label {
+      text: qsTr("Sample size (<i>n</i>)")
+      width: 400
+    }
+
+    IntegerField
+    {
+      name: "reference_n"
+      defaultValue: 20
+      fieldWidth: jaspTheme.textFieldWidth
+      min: 2
+      onEditingFinished : {
+        summary_dirty.checked = true
+      }
+    }
+
+    IntegerField
+    {
+      name: "comparison_n"
+      defaultValue: 20
+      fieldWidth: jaspTheme.textFieldWidth
+      min: 2
+      onEditingFinished : {
+        summary_dirty.checked = true
+      }
+    }
 
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
 
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
+  Group {
+    TextField
+    {
+      name: "outcome_variable_name"
+      label: qsTr("Outcome variable name")
+      placeholderText: qsTr("Outcome variable")
+    }
 
-		DropDown
-      {
-        name: "effect_size"
-        label: qsTr("Effect size of interest")
-        enabled: from_raw.checked
-        values:
+
+    TextField
+    {
+      name: "grouping_variable_name"
+      label: qsTr("Grouping variable name")
+      placeholderText: qsTr("Grouping variable")
+    }
+
+  }
+
+  CheckBox
+  {
+    name: "summary_dirty";
+    id: summary_dirty
+    visible: false
+  }
+
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
+
+    DropDown
+    {
+      name: "effect_size"
+      label: qsTr("Effect size of interest")
+      enabled: !switch_source.is_summary
+      values:
           [
-            { label: qsTr("Mean difference"), value: "mean_difference"},
-            { label: qsTr("Median difference"), value: "median_difference"}
-          ]
-        id: effect_size
-      }
+        { label: qsTr("Mean difference"), value: "mean_difference"},
+        { label: qsTr("Median difference"), value: "median_difference"}
+      ]
+      id: effect_size
+    }
 
     CheckBox {
-	    name: "assume_equal_variance";
-	    id: assume_equal_variance
-	    label: qsTr("Assume equal variances")
-	    checked: true
-	    enabled: effect_size.currentValue == "mean_difference"
+      name: "assume_equal_variance";
+      id: assume_equal_variance
+      label: qsTr("Assume equal variances")
+      checked: true
+      enabled: effect_size.currentValue == "mean_difference"
     }
 
-	}
+  }
 
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
-	  CheckBox
-	  {
-	    name: "show_calculations";
-	    label: qsTr("Calculation components");
-	    enabled: effect_size.currentValue == "mean_difference" & assume_equal_variance.checked
-	   }
-	  CheckBox {
-	    name: "show_ratio";
-	    id: show_ratio
-	    label: qsTr("Ratio between groups (appropriate only for true ratio scales)")
-	    enabled: from_raw.checked
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
     }
-	}
+    CheckBox
+    {
+      name: "show_calculations";
+      label: qsTr("Calculation components");
+      enabled: effect_size.currentValue == "mean_difference" & assume_equal_variance.checked
+    }
+    CheckBox {
+      name: "show_ratio";
+      id: show_ratio
+      label: qsTr("Ratio between groups (appropriate only for true ratio scales)")
+      enabled: !switch_source.is_summary
+    }
+  }
 
 
   Esci.FigureOptions {
-          Section
+    is_summary: switch_source.is_summary
+  }
+
+  Section
   {
     title: qsTr("Aesthetics")
 
@@ -684,7 +652,7 @@ Form
         name: "shape_raw_reference"
         id: shape_raw_reference
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ShapeSelect
@@ -692,7 +660,7 @@ Form
         name: "shape_raw_comparison"
         id: shape_raw_comparison
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Label {
@@ -709,7 +677,7 @@ Form
         name: "size_raw_reference"
         id: size_raw_reference
         defaultValue: 2
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -718,7 +686,7 @@ Form
         name: "size_raw_comparison"
         id: size_raw_comparison
         defaultValue: 2
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -735,7 +703,7 @@ Form
         name: "color_raw_reference"
         id: color_raw_reference
         startValue: "#008DF9"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -743,7 +711,7 @@ Form
         name: "color_raw_comparison"
         id: color_raw_comparison
         startValue: "#009F81"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Label {
@@ -760,7 +728,7 @@ Form
         name: "fill_raw_reference"
         id: fill_raw_reference
         startValue: "NA"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -768,7 +736,7 @@ Form
         name: "fill_raw_comparison"
         id: fill_raw_comparison
         startValue: "NA"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Label {
@@ -784,7 +752,7 @@ Form
       {
         name: "alpha_raw_reference"
         id: alpha_raw_reference
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -792,7 +760,7 @@ Form
       {
         name: "alpha_raw_comparison"
         id: alpha_raw_comparison
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -808,11 +776,9 @@ Form
 
   } // end aesthetics
 
-  }
 
-
-	Esci.HeOptions {
-	  id: myHeOptions
+  Esci.HeOptions {
+    id: myHeOptions
     null_value_enabled: false
     rope_units_visible: evaluate_hypotheses_checked
     hgrid_columns: 4

--- a/inst/qml/jasp_estimate_pdiff_one.qml
+++ b/inst/qml/jasp_estimate_pdiff_one.qml
@@ -24,173 +24,142 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
+  columns: 1
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
   function not_case_label_adjust() {
     not_case_label.text = "Not " + case_label.text
   }
 
-
-
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-    }
   }
 
-
-
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-  	VariablesForm
-  	{
-  		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-  		AvailableVariablesList { name: "allVariablesList" }
-  		AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["nominal", "ordinal"] }
-  	}
-
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["nominal", "ordinal"] }
   }
 
+  Group {
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
+    visible: switch_source.is_summary
 
-    Group {
-
-
-
-      GridLayout {
+    GridLayout {
       id: sgrid
       columns: 2
       rowSpacing: 1
       columnSpacing: 1
 
-        Item {}
+      Item {}
 
-        TextField
-        {
-          name: "outcome_variable_name"
-          placeholderText: qsTr("Outcome variable")
+      TextField
+      {
+        name: "outcome_variable_name"
+        placeholderText: qsTr("Outcome variable")
+      }
+
+
+      TextField
+      {
+        name: "case_label"
+        id: case_label
+        label: ""
+        defaultValue: "Affected"
+        onEditingFinished : {
+          summary_dirty.checked = true
         }
+      }
 
-
-        TextField
-        {
-          name: "case_label"
-          id: case_label
-          label: ""
-          defaultValue: "Affected"
-          onEditingFinished : {
-            summary_dirty.checked = true
-          }
+      IntegerField
+      {
+        name: "cases"
+        label: ""
+        defaultValue: 20
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
+        onEditingFinished : {
+          summary_dirty.checked = true
         }
+      }
 
-        IntegerField
-        {
-          name: "cases"
-          label: ""
-          defaultValue: 20
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
-          onEditingFinished : {
-            summary_dirty.checked = true
-          }
+      TextField
+      {
+        name: "not_case_label"
+        id: not_case_label
+        enabled: false
+        label: ""
+        value: qsTr("Not ") + case_label.value
+      }
+
+      IntegerField
+      {
+        name: "not_cases"
+        label: ""
+        defaultValue: 80
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
+        onEditingFinished : {
+          summary_dirty.checked = true
         }
+      }
+    }  // 2 column grid
 
-        TextField
-        {
-          name: "not_case_label"
-          id: not_case_label
-          enabled: false
-          label: ""
-          value: qsTr("Not ") + case_label.value
-        }
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
+    }
+  }  // end of group for summary
 
-        IntegerField
-        {
-          name: "not_cases"
-          label: ""
-          defaultValue: 80
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
-          onEditingFinished : {
-            summary_dirty.checked = true
-          }
-        }
-      }  // 2 column grid
 
-            CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
-    }  // end of group for summary
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
 
+    CheckBox
+    {
+      name: "count_NA";
+      label: qsTr("Missing cases are counted")
+      enabled: !switch_source.is_summary
+      visible: !switch_source.is_summary
+    }
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-		CheckBox
-	  {
-	    name: "count_NA";
-	    label: qsTr("Missing cases are counted")
-	    enabled: from_raw.checked
-	    visible: from_raw.checked
-	   }
-	}
-
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
-	  CheckBox
-	  {
-	    name: "plot_possible";
-	    label: qsTr("Lines at proportion intervals");
-	   }
-	}
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
+    CheckBox
+    {
+      name: "plot_possible";
+      label: qsTr("Lines at proportion intervals");
+    }
+  }
 
 
   Esci.FigureOptions {
+    is_summary: switch_source.is_summary
     simple_labels_enabled: false
     simple_labels_visible: false
     difference_axis_grid_visible: false
@@ -198,8 +167,9 @@ Form
     distributions_grid_visible: false
     ymin_placeholderText: "0"
     ymax_placeholderText: "1"
+  }
 
-        Section
+  Section
   {
     title: qsTr("Aesthetics")
 
@@ -207,13 +177,11 @@ Form
 
     }
 
-
-
     Group
     {
-    title: "<b>CI</b>"
-    columns: 2
-    Layout.columnSpan: 2
+      title: "<b>CI</b>"
+      columns: 2
+      Layout.columnSpan: 2
 
       Esci.LineTypeSelect
       {
@@ -223,13 +191,7 @@ Form
       }
 
     }
-
-
   }
-
-  }
-
-
 
   Esci.HeOptions {
     id: myHeOptions
@@ -238,6 +200,5 @@ Form
     null_value_negativeValues: false
     null_boundary_max: 1
   }
-
 
 }

--- a/inst/qml/jasp_estimate_pdiff_paired.qml
+++ b/inst/qml/jasp_estimate_pdiff_paired.qml
@@ -24,208 +24,180 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
-	property alias conf_level_value: conf_level.value
+  id: form
+  columns: 1
+  property alias conf_level_value: conf_level.value
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
 
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-    }
   }
 
 
-
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-  	VariablesForm
-  	{
-  		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-  		AvailableVariablesList { name: "allVariablesList" }
-  		AssignedVariablesList { name: "reference_measure"; title: qsTr("Reference measure"); allowedColumns: ["nominal"]; singleVariable: true }
-  		AssignedVariablesList { name: "comparison_measure"; title: qsTr("Comparison measure"); allowedColumns: ["nominal"]; singleVariable: true }
-  	}
-
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "reference_measure"; title: qsTr("Reference measure"); allowedColumns: ["nominal"]; singleVariable: true }
+    AssignedVariablesList { name: "comparison_measure"; title: qsTr("Comparison measure"); allowedColumns: ["nominal"]; singleVariable: true }
   }
 
+  Group {
+    visible: switch_source.is_summary
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
-
-    Group {
-
-
-      GridLayout {
+    GridLayout {
       id: sgrid
       columns: 3
       rowSpacing: 1
       columnSpacing: 1
 
-        Item {}
+      Item {}
 
-        TextField {
-          name: "comparison_measure_name"
-          Layout.columnSpan: 2
-          label: ""
-          placeholderText: qsTr("Post-test")
-          enabled: from_summary.checked
-          fieldWidth: 2*jaspTheme.textFieldWidth
-        }
+      TextField {
+        name: "comparison_measure_name"
+        Layout.columnSpan: 2
+        label: ""
+        placeholderText: qsTr("Post-test")
+        enabled: switch_source.is_summary
+        fieldWidth: 2*jaspTheme.textFieldWidth
+      }
 
 
-        TextField {
-          name: "reference_measure_name"
-          label: ""
-          placeholderText: qsTr("Pre-test")
-          enabled: from_summary.checked
-        }
+      TextField {
+        name: "reference_measure_name"
+        label: ""
+        placeholderText: qsTr("Pre-test")
+        enabled: switch_source.is_summary
+      }
 
-        TextField
-        {
-          name: "case_label"
-          id: case_label
-          label: ""
-          defaultValue: qsTr("Sick")
-          enabled: from_summary.checked
-        }
+      TextField
+      {
+        name: "case_label"
+        id: case_label
+        label: ""
+        defaultValue: qsTr("Sick")
+        enabled: switch_source.is_summary
+      }
 
-        TextField
-        {
-          name: "not_case_label"
-          id: not_case_label
-          label: ""
-          defaultValue: qsTr("Well")
-          enabled: from_summary.checked
-        }
+      TextField
+      {
+        name: "not_case_label"
+        id: not_case_label
+        label: ""
+        defaultValue: qsTr("Well")
+        enabled: switch_source.is_summary
+      }
 
-        Label {
-          id: case_label_again
-          text: case_label.value
-          enabled: false
-        }
+      Label {
+        id: case_label_again
+        text: case_label.value
+        enabled: false
+      }
 
-        IntegerField
-        {
-          name: "cases_consistent"
-          id: cases_consistent
-          label: ""
-          defaultValue: 18
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "cases_consistent"
+        id: cases_consistent
+        label: ""
+        defaultValue: 18
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
-        IntegerField
-        {
-          name: "cases_inconsistent"
-          id: cases_inconsistent
-          label: ""
-          defaultValue: 4
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "cases_inconsistent"
+        id: cases_inconsistent
+        label: ""
+        defaultValue: 4
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
 
-        Label {
-          id: not_case_label_again
-          text: not_case_label.value
-          enabled: false
-        }
+      Label {
+        id: not_case_label_again
+        text: not_case_label.value
+        enabled: false
+      }
 
-        IntegerField
-        {
-          name: "not_cases_inconsistent"
-          id: not_cases_inconsistent
-          label: ""
-          defaultValue: 12
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "not_cases_inconsistent"
+        id: not_cases_inconsistent
+        label: ""
+        defaultValue: 12
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
-        IntegerField
-        {
-          name: "not_cases_consistent"
-          id: not_cases_consistent
-          label: ""
-          defaultValue: 5
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "not_cases_consistent"
+        id: not_cases_consistent
+        label: ""
+        defaultValue: 5
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
 
-      }  // 3 column grid
+    }  // 3 column grid
 
-                  CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
-    }  // end of group for summary
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
+    }
+  }  // end of group for summary
+
+
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
 
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-	}
-
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
   }
 
 
   Esci.FigureOptions {
+    is_summary: switch_source.is_summary
     simple_labels_enabled: true
     simple_labels_visible: true
     difference_axis_grid_visible: true
@@ -236,8 +208,9 @@ Form
     ymax_placeholderText: "auto"
     width_defaultValue: 400
     height_defaultValue: 450
+  }
 
-        Section
+  Section
   {
     title: qsTr("Aesthetics")
 
@@ -276,22 +249,13 @@ Form
         name: "linetype_summary_difference"
         id: linetype_summary_difference
       }
-
-
-
     }
-
-
   }
-
-  }
-
 
   Esci.HeOptions {
     id: myHeOptions
     null_value_enabled: false
     null_boundary_max: 1
   }
-
 
 }

--- a/inst/qml/jasp_estimate_pdiff_two.qml
+++ b/inst/qml/jasp_estimate_pdiff_two.qml
@@ -24,263 +24,240 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
-	property alias conf_level_value: conf_level.value
+  id: form
+  columns: 1
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  property alias conf_level_value: conf_level.value
+
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
 
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-    }
   }
 
 
 
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-  	VariablesForm
-  	{
-  		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-  		AvailableVariablesList { name: "allVariablesList" }
-  		AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["nominal", "ordinal"] }
-  		AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal", "ordinal"]; singleVariable: true }
-  	}
-
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "outcome_variable"; title: qsTr("Outcome variable"); allowedColumns: ["nominal", "ordinal"] }
+    AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal", "ordinal"]; singleVariable: true }
   }
 
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
 
-    Group {
+  Group {
 
+    visible: switch_source.is_summary
 
-      GridLayout {
+    GridLayout {
       id: sgrid
       columns: 3
       rowSpacing: 1
       columnSpacing: 1
 
-        Item {}
+      Item {}
 
 
-        TextField {
-          name: "grouping_variable_name"
-          Layout.columnSpan: 2
-          label: ""
-          placeholderText: qsTr("Grouping variable")
-          fieldWidth: 2*jaspTheme.textFieldWidth
-        }
+      TextField {
+        name: "grouping_variable_name"
+        Layout.columnSpan: 2
+        label: ""
+        placeholderText: qsTr("Grouping variable")
+        fieldWidth: 2*jaspTheme.textFieldWidth
+      }
 
 
-        TextField {
-          name: "outcome_variable_name"
-          label: ""
-          placeholderText: qsTr("Outcome variable")
-        }
+      TextField {
+        name: "outcome_variable_name"
+        label: ""
+        placeholderText: qsTr("Outcome variable")
+      }
 
-        TextField {
-          name: "grouping_variable_level1"
-          label: ""
-          placeholderText: qsTr("Control")
-        }
+      TextField {
+        name: "grouping_variable_level1"
+        label: ""
+        placeholderText: qsTr("Control")
+      }
 
-        TextField {
-          name: "grouping_variable_level2"
-          label: ""
-          placeholderText: qsTr("Treated")
-        }
+      TextField {
+        name: "grouping_variable_level2"
+        label: ""
+        placeholderText: qsTr("Treated")
+      }
 
 
-        TextField
-        {
-          name: "case_label"
-          id: case_label
-          label: ""
-          placeholderText: qsTr("Sick")
-        }
+      TextField
+      {
+        name: "case_label"
+        id: case_label
+        label: ""
+        placeholderText: qsTr("Sick")
+      }
 
-        IntegerField
-        {
-          name: "reference_cases"
-          id: reference_cases
-          label: ""
-          defaultValue: 20
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "reference_cases"
+        id: reference_cases
+        label: ""
+        defaultValue: 20
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
-        IntegerField
-        {
-          name: "comparison_cases"
-          id: comparison_cases
-          label: ""
-          defaultValue: 40
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "comparison_cases"
+        id: comparison_cases
+        label: ""
+        defaultValue: 40
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
-        TextField
-        {
-          name: "not_case_label"
-          id: not_case_label
-          label: ""
-          placeholderText: qsTr("Well")
-        }
+      TextField
+      {
+        name: "not_case_label"
+        id: not_case_label
+        label: ""
+        placeholderText: qsTr("Well")
+      }
 
-        IntegerField
-        {
-          name: "reference_not_cases"
-          id: reference_not_cases
-          label: ""
-          defaultValue: 80
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "reference_not_cases"
+        id: reference_not_cases
+        label: ""
+        defaultValue: 80
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
-        IntegerField
-        {
-          name: "comparison_not_cases"
-          id: comparison_not_cases
-          label: ""
-          defaultValue: 60
-          min: 0
-          fieldWidth: jaspTheme.textFieldWidth
+      IntegerField
+      {
+        name: "comparison_not_cases"
+        id: comparison_not_cases
+        label: ""
+        defaultValue: 60
+        min: 0
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
-      }  // 3 column grid
+    }  // 3 column grid
 
-                  CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
-    }  // end of group for summary
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
+    }
+  }  // end of group for summary
 
+
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
+
+    CheckBox
+    {
+      name: "count_NA";
+      label: qsTr("Missing cases are counted")
+      enabled: !switch_source.is_summary
+    }
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-		CheckBox
-	  {
-	    name: "count_NA";
-	    label: qsTr("Missing cases are counted")
-	    enabled: from_raw.checked
-	   }
-	}
-
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
-	  CheckBox
-	  {
-	    name: "show_ratio";
-	    label: qsTr("Odds ratio");
-	   }
-	  CheckBox
-	  {
-	    name: "show_phi";
-	    label: qsTr("Correlation (ϕ)");
-	   }
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
+    CheckBox
+    {
+      name: "show_ratio";
+      label: qsTr("Odds ratio");
+    }
+    CheckBox
+    {
+      name: "show_phi";
+      label: qsTr("Correlation (ϕ)");
+    }
 
 
-      GridLayout {
+    GridLayout {
       id: show_chi_square_grid
       columns: 4
-    	 	CheckBox
-    	  {
-    	    name: "show_chi_square";
-    	    id: show_chi_square;
-    	    label: qsTr("&#120536;<sup>2</sup> analysis");
-    	  }
+      CheckBox
+      {
+        name: "show_chi_square";
+        id: show_chi_square;
+        label: qsTr("&#120536;<sup>2</sup> analysis");
+      }
 
 
-        RadioButtonGroup {
-          columns: 3
-          name: "chi_table_option"
-          id: chi_table_option
+      RadioButtonGroup {
+        columns: 3
+        name: "chi_table_option"
+        id: chi_table_option
 
-          RadioButton {
-            value: "observed";
-            label: qsTr("Observed frequencies");
-            id: observed
-            enabled: show_chi_square.checked
-          }
+        RadioButton {
+          value: "observed";
+          label: qsTr("Observed frequencies");
+          id: observed
+          enabled: show_chi_square.checked
+        }
 
-          RadioButton {
-            value: "expected";
-            label: qsTr("Expected frequencies");
-            id: expected
-            enabled: show_chi_square.checked
-          }
+        RadioButton {
+          value: "expected";
+          label: qsTr("Expected frequencies");
+          id: expected
+          enabled: show_chi_square.checked
+        }
 
-          RadioButton {
-            value: "both";
-            label: qsTr("Both");
-            id: both;
-            checked: true;
-            enabled: show_chi_square.checked
-          }
+        RadioButton {
+          value: "both";
+          label: qsTr("Both");
+          id: both;
+          checked: true;
+          enabled: show_chi_square.checked
+        }
       } // end chi_table_option
 
     } // end show_chi_square 4-column grid
 
-}
+  }
 
 
   Esci.FigureOptions {
+    is_summary: switch_source.is_summary
     simple_labels_enabled: true
     simple_labels_visible: true
     difference_axis_grid_visible: true
@@ -289,8 +266,9 @@ Form
     distributions_grid_visible: false
     ymin_placeholderText: "auto"
     ymax_placeholderText: "auto"
+  }
 
-    Section
+  Section
   {
     title: qsTr("Aesthetics")
 
@@ -330,16 +308,9 @@ Form
         id: linetype_summary_difference
       }
 
-
-
     }
 
-
   }
-
-  }
-
-
 
   Esci.HeOptions {
     id: myHeOptions

--- a/inst/qml/jasp_estimate_r.qml
+++ b/inst/qml/jasp_estimate_r.qml
@@ -24,60 +24,39 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
-	property alias conf_level_value: conf_level.value
+  id: form
+  columns: 1
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  property alias conf_level_value: conf_level.value
+
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-    }
   }
 
 
 
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-  	VariablesForm
-  	{
-  		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-  		AvailableVariablesList { name: "allVariablesList" }
-  		AssignedVariablesList { name: "x"; title: qsTr("<i>X</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
-  		AssignedVariablesList { name: "y"; title: qsTr("<i>Y</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
-  	}
-
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "x"; title: qsTr("<i>X</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
+    AssignedVariablesList { name: "y"; title: qsTr("<i>Y</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
   }
 
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
 
-    Group {
+  Group {
 
+    columns : 1
+    visible: switch_source.is_summary
 
-      GridLayout {
+    GridLayout {
       id: sgrid
       columns: 3
       rowSpacing: 1
@@ -88,18 +67,18 @@ Form
         text: qsTr("Correlation (<i>r</i>)")
       }
 
-        DoubleField {
-          name: "r"
-          defaultValue: 0.5
-          negativeValues: true
-          min: -1
-          max: 1
-          enabled: from_summary.checked
-          fieldWidth: jaspTheme.textFieldWidth
+      DoubleField {
+        name: "r"
+        defaultValue: 0.5
+        negativeValues: true
+        min: -1
+        max: 1
+        enabled: switch_source.is_summary
+        fieldWidth: jaspTheme.textFieldWidth
         onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
       Label {
         text: " "
@@ -109,16 +88,16 @@ Form
         text: qsTr("Sample size (<i>N</i>)")
       }
 
-        DoubleField {
-          name: "n"
-          defaultValue: 20
-          min: 2
-          fieldWidth: jaspTheme.textFieldWidth
-          enabled: from_summary.checked
-                  onEditingFinished : {
+      DoubleField {
+        name: "n"
+        defaultValue: 20
+        min: 2
+        fieldWidth: jaspTheme.textFieldWidth
+        enabled: switch_source.is_summary
+        onEditingFinished : {
           summary_dirty.checked = true
-          }
         }
+      }
 
       Label {
         text: " "
@@ -129,151 +108,150 @@ Form
         text: qsTr("<i>X</i>-variable name")
       }
 
-        TextField
-        {
-          name: "x_variable_name"
-          id: x_variable_name
-          fieldWidth: jaspTheme.textFieldWidth * 2
-          Layout.columnSpan: 2
-          placeholderText: qsTr("X variable")
-          enabled: from_summary.checked
-        }
+      TextField
+      {
+        name: "x_variable_name"
+        id: x_variable_name
+        fieldWidth: jaspTheme.textFieldWidth * 2
+        Layout.columnSpan: 2
+        placeholderText: qsTr("X variable")
+        enabled: switch_source.is_summary
+      }
 
 
       Label {
         text: qsTr("<i>Y</i>-variable name")
       }
 
-        TextField
-        {
-          name: "y_variable_name"
-          id: y_variable_name
-          fieldWidth: jaspTheme.textFieldWidth * 2
-          Layout.columnSpan: 2
-          placeholderText: qsTr("Y variable")
-          enabled: from_summary.checked
-        }
+      TextField
+      {
+        name: "y_variable_name"
+        id: y_variable_name
+        fieldWidth: jaspTheme.textFieldWidth * 2
+        Layout.columnSpan: 2
+        placeholderText: qsTr("Y variable")
+        enabled: switch_source.is_summary
+      }
 
-      }  // 1 column grid
+    }  // 1 column grid
 
-                        CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
+    }
 
-    }  // end of group for summary
+  }  // end of group for summary
+
+
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
 
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-	}
-
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
   }
 
 
   Group {
     title: qsTr("<b>Regression</b>")
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    Layout.columnSpan: 2
+    enabled: !switch_source.is_summary
+    visible: !switch_source.is_summary
 
     CheckBox
-	  {
-	    name: "do_regression";
-	    id: do_regression
-	    label: qsTr("Regression analysis")
-	    enabled: from_raw.checked
-      visible: from_raw.checked
-	   }
+    {
+      name: "do_regression";
+      id: do_regression
+      label: qsTr("Regression analysis")
+      enabled: !switch_source.is_summary
+      visible: !switch_source.is_summary
+    }
 
-	  GridLayout {
-	    columns: 3
+    GridLayout {
+      columns: 3
 
-	      CheckBox {
-    	    name: "show_line";
-    	    id: show_line
-	        label: qsTr("Line")
-	        enabled: do_regression.checked
-          visible: from_raw.checked
-	      }
+      CheckBox {
+        name: "show_line";
+        id: show_line
+        label: qsTr("Line")
+        enabled: do_regression.checked
+        visible: !switch_source.is_summary
+      }
 
-	      CheckBox {
-    	    name: "show_line_CI";
-    	    id: show_line_CI
-	        label: qsTr("CI on Line")
-	        enabled: do_regression.checked
-          visible: from_raw.checked
-	      }
+      CheckBox {
+        name: "show_line_CI";
+        id: show_line_CI
+        label: qsTr("CI on Line")
+        enabled: do_regression.checked
+        visible: !switch_source.is_summary
+      }
 
-	      CheckBox {
-    	    name: "show_residuals";
-    	    id: show_residuals
-	        label: qsTr("Residuals")
-	        enabled: do_regression.checked
-          visible: from_raw.checked
-	      }
-	  }
+      CheckBox {
+        name: "show_residuals";
+        id: show_residuals
+        label: qsTr("Residuals")
+        enabled: do_regression.checked
+        visible: !switch_source.is_summary
+      }
+    }
 
     CheckBox
-	  {
-	    name: "show_PI";
-	    id: show_PI
-	    label: qsTr("Prediction interval")
-	    enabled: do_regression.checked
-      visible: from_raw.checked
-	   }
+    {
+      name: "show_PI";
+      id: show_PI
+      label: qsTr("Prediction interval")
+      enabled: do_regression.checked
+      visible: !switch_source.is_summary
+    }
 
-	   TextField {
-         name: "predict_from_x"
-         id: predict_from_x
-         label: qsTr("Enter <i>X</i> value to generate prediction (<i>&#374;</i>)")
-         placeholderText: qsTr("Enter an X value")
-   	     enabled: do_regression.checked
-         visible: from_raw.checked
-     }
+    TextField {
+      name: "predict_from_x"
+      id: predict_from_x
+      label: qsTr("Enter <i>X</i> value to generate prediction (<i>&#374;</i>)")
+      placeholderText: qsTr("Enter an X value")
+      enabled: do_regression.checked
+      visible: !switch_source.is_summary
+    }
 
   }
 
 
   Esci.ScatterplotOptions {
+    is_summary: switch_source.is_summary
     sp_other_options_grid_enabled: true
     sp_other_options_grid_visible: true
+  }
 
-    Section
+  Section
   {
     title: qsTr("Scatterplot aesthetics")
-    enabled: from_raw.checked
-    visible: from_raw.checked
+    enabled: !switch_source.is_summary
+    visible: !switch_source.is_summary
 
-     GridLayout {
+    GridLayout {
       id: sp_raw_grid
       columns: 1
       Layout.columnSpan: 2
 
       Label {
-          text: qsTr("<b>Raw data</b>")
+        text: qsTr("<b>Raw data</b>")
       }
 
       Esci.ShapeSelect
@@ -282,7 +260,7 @@ Form
         id: sp_shape_raw_reference
         label: qsTr("Shape")
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.SizeSelect
@@ -291,7 +269,7 @@ Form
         id: sp_size_raw_reference
         label: qsTr("Size")
         defaultValue: 3
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -301,7 +279,7 @@ Form
         id: sp_color_raw_reference
         label: qsTr("Outline")
         startValue: "black"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -310,7 +288,7 @@ Form
         id: sp_fill_raw_reference
         label: qsTr("Fill")
         startValue: "#008DF9"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.AlphaSelect
@@ -318,10 +296,9 @@ Form
         name: "sp_alpha_raw_reference"
         label: qsTr("Transparency")
         id: sp_alpha_raw_reference
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         defaultValue: 75
       }
-
 
     }
 
@@ -332,24 +309,24 @@ Form
       enabled: do_regression.checked
 
       Label {
-          text: ""
+        text: ""
       }
 
       Label {
-          text: qsTr("<u>Regression</u>")
+        text: qsTr("<u>Regression</u>")
       }
 
       Label {
-          text: qsTr("<u>Prediction</u>")
+        text: qsTr("<u>Prediction</u>")
       }
 
 
       Label {
-          text: qsTr("<u>Residual</u>")
+        text: qsTr("<u>Residual</u>")
       }
 
       Label {
-          text: qsTr("Style")
+        text: qsTr("Style")
       }
 
       Esci.LineTypeSelect
@@ -375,7 +352,7 @@ Form
       }
 
       Label {
-          text: qsTr("Thickness")
+        text: qsTr("Thickness")
       }
 
       IntegerField
@@ -406,7 +383,7 @@ Form
       }
 
       Label {
-          text: qsTr("Color")
+        text: qsTr("Color")
       }
 
 
@@ -436,7 +413,7 @@ Form
 
 
       Label {
-          text: qsTr("Transparency")
+        text: qsTr("Transparency")
       }
 
 
@@ -471,7 +448,7 @@ Form
       Layout.columnSpan: 2
 
       Label {
-          text: qsTr("<b>Prediction from <i>X</i></b>")
+        text: qsTr("<b>Prediction from <i>X</i></b>")
       }
 
       IntegerField
@@ -481,7 +458,7 @@ Form
         label: qsTr("Label size")
         min: 1
         max: 10
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -490,7 +467,7 @@ Form
         id: sp_prediction_color
         label: qsTr("Label color")
         startValue: "#E20134"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -503,24 +480,24 @@ Form
       enabled: do_regression.checked
 
       Label {
-          text: ""
+        text: ""
       }
 
       Label {
-          text: qsTr("<u>Guidelines</u>")
+        text: qsTr("<u>Guidelines</u>")
       }
 
       Label {
-          text: qsTr("<u>PI</u>")
+        text: qsTr("<u>PI</u>")
       }
 
 
       Label {
-          text: qsTr("<u>CI</u>")
+        text: qsTr("<u>CI</u>")
       }
 
       Label {
-          text: qsTr("Style")
+        text: qsTr("Style")
       }
 
 
@@ -528,7 +505,7 @@ Form
       {
         name: "sp_linetype_ref"
         id: sp_linetype_ref
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         startValue: "dotted"
       }
 
@@ -547,7 +524,7 @@ Form
       }
 
       Label {
-          text: qsTr("Thickness")
+        text: qsTr("Thickness")
       }
 
       IntegerField
@@ -556,7 +533,7 @@ Form
         defaultValue: 1
         min: 1
         max: 10
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       IntegerField
@@ -578,7 +555,7 @@ Form
       }
 
       Label {
-          text: qsTr("Color")
+        text: qsTr("Color")
       }
 
 
@@ -587,7 +564,7 @@ Form
         name: "sp_color_ref"
         id: sp_color_ref
         startValue: 'gray60'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -608,7 +585,7 @@ Form
 
 
       Label {
-          text: qsTr("Transparency")
+        text: qsTr("Transparency")
       }
 
 
@@ -616,7 +593,7 @@ Form
       {
         name: "sp_alpha_ref"
         id: sp_alpha_ref
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.AlphaSelect
@@ -634,15 +611,12 @@ Form
       }
 
     }
-
-  }
-
-
   }
 
 
   Esci.FigureOptions {
     title: qsTr("Estimation figure options")
+    is_summary: switch_source.is_summary
     simple_labels_enabled: false
     simple_labels_visible: false
     difference_axis_grid_visible: false
@@ -653,8 +627,9 @@ Form
     ymax_placeholderText: "1"
     width_defaultValue: 300
     height_defaultValue: 400
+  }
 
-    Section
+  Section
   {
     title: qsTr("Estimation figure aesthetics")
 
@@ -663,9 +638,9 @@ Form
 
     Group
     {
-    title: "<b>CI</b>"
-    columns: 2
-    Layout.columnSpan: 2
+      title: "<b>CI</b>"
+      columns: 2
+      Layout.columnSpan: 2
 
       Esci.LineTypeSelect
       {
@@ -697,10 +672,6 @@ Form
         label: qsTr("Transparency")
       }
     }  // end ci grid
-
-
-
-  }
 
   }
 

--- a/inst/qml/jasp_estimate_rdiff_two.qml
+++ b/inst/qml/jasp_estimate_rdiff_two.qml
@@ -24,279 +24,252 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
-	property alias conf_level_value: conf_level.value
+  id: form
+  columns: 1
 
-	function alpha_adjust() {
-	  myHeOptions.currentConfLevel = conf_level.value
+  property alias conf_level_value: conf_level.value
+
+  function alpha_adjust() {
+    myHeOptions.currentConfLevel = conf_level.value
   }
 
 
-  RadioButtonGroup {
-    columns: 2
-    name: "switch"
+  Esci.RawOrSummary
+  {
     id: switch_source
-
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze full data");
-      checked: true;
-      id: from_raw
-    }
-
-    RadioButton {
-      value: "from_summary";
-      label: qsTr("Analyze summary data");
-      id: from_summary
-    }
+    onValueChanged: switch_adjust()
   }
 
 
-
-  Section {
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    expanded: from_raw.checked
-
-  	VariablesForm
-  	{
-  		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-  		AvailableVariablesList { name: "allVariablesList" }
-  		AssignedVariablesList { name: "x"; title: qsTr("<i>X</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
-  		AssignedVariablesList { name: "y"; title: qsTr("<i>Y</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
-  		AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal"]; singleVariable: true }
-  	}
-
+  VariablesForm
+  {
+    visible: !switch_source.is_summary
+    preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+    AvailableVariablesList { name: "allVariablesList" }
+    AssignedVariablesList { name: "x"; title: qsTr("<i>X</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
+    AssignedVariablesList { name: "y"; title: qsTr("<i>Y</i> Variable"); allowedColumns: ["scale"]; singleVariable: true }
+    AssignedVariablesList { name: "grouping_variable"; title: qsTr("Grouping variable"); allowedColumns: ["nominal"]; singleVariable: true }
   }
 
 
-  Section {
-    enabled: from_summary.checked
-    visible: from_summary.checked
-    expanded: from_summary.checked
+  Group {
+    columns: 1
+    visible: switch_source.is_summary
 
-    Group {
-
-
-      GridLayout {
+    GridLayout {
       id: sgrid
       columns: 3
       rowSpacing: 1
       columnSpacing: 1
 
-        Label {
-          text: ""
-        }
+      Label {
+        text: ""
+      }
 
-        Label {
-          text: qsTr("<b>Reference group</b>")
-        }
+      Label {
+        text: qsTr("<b>Reference group</b>")
+      }
 
-        Label {
-          text: qsTr("<b>Comparison group</b>")
-        }
+      Label {
+        text: qsTr("<b>Comparison group</b>")
+      }
 
-        Label {
-          text: qsTr("Name")
-        }
+      Label {
+        text: qsTr("Name")
+      }
 
-        TextField
-        {
-          name: "reference_level_name"
-          id: reference_level_name
-          label: ""
-          placeholderText: qsTr("Reference level")
-          enabled: from_summary.checked
-          fieldWidth: jaspTheme.textFieldWidth
-        }
+      TextField
+      {
+        name: "reference_level_name"
+        id: reference_level_name
+        label: ""
+        placeholderText: qsTr("Reference level")
+        enabled: switch_source.is_summary
+        fieldWidth: jaspTheme.textFieldWidth
+      }
 
 
-        TextField
-        {
-          name: "comparison_level_name"
-          id: comparison_level_name
-          label: ""
-          placeholderText: qsTr("Comparison level")
-          enabled: from_summary.checked
-          fieldWidth: jaspTheme.textFieldWidth
-        }
+      TextField
+      {
+        name: "comparison_level_name"
+        id: comparison_level_name
+        label: ""
+        placeholderText: qsTr("Comparison level")
+        enabled: switch_source.is_summary
+        fieldWidth: jaspTheme.textFieldWidth
+      }
 
-        Label {
-          text: qsTr("Correlation (<i>r</i>)")
-        }
+      Label {
+        text: qsTr("Correlation (<i>r</i>)")
+      }
 
-        DoubleField {
-          name: "reference_r"
-          label: ""
-          defaultValue: 0.5
-          negativeValues: true
-          min: -1
-          max: 1
-          fieldWidth: jaspTheme.textFieldWidth
-          enabled: from_summary.checked
-                  onEditingFinished : {
+      DoubleField {
+        name: "reference_r"
+        label: ""
+        defaultValue: 0.5
+        negativeValues: true
+        min: -1
+        max: 1
+        fieldWidth: jaspTheme.textFieldWidth
+        enabled: switch_source.is_summary
+        onEditingFinished : {
           summary_dirty.checked = true
 
         }
-        }
+      }
 
-        DoubleField {
-          name: "comparison_r"
-          label: ""
-          defaultValue: 0.75
-          negativeValues: true
-          min: -1
-          max: 1
-          fieldWidth: jaspTheme.textFieldWidth
-          enabled: from_summary.checked
-                  onEditingFinished : {
+      DoubleField {
+        name: "comparison_r"
+        label: ""
+        defaultValue: 0.75
+        negativeValues: true
+        min: -1
+        max: 1
+        fieldWidth: jaspTheme.textFieldWidth
+        enabled: switch_source.is_summary
+        onEditingFinished : {
           summary_dirty.checked = true
 
         }
-        }
+      }
 
 
-        Label {
-          text: qsTr("Sample size (<i>N</i>)")
-        }
+      Label {
+        text: qsTr("Sample size (<i>N</i>)")
+      }
 
-        DoubleField {
-          name: "reference_n"
-          label: ""
-          defaultValue: 20
-          min: 2
-          fieldWidth: jaspTheme.textFieldWidth
-          enabled: from_summary.checked
-                  onEditingFinished : {
+      DoubleField {
+        name: "reference_n"
+        label: ""
+        defaultValue: 20
+        min: 2
+        fieldWidth: jaspTheme.textFieldWidth
+        enabled: switch_source.is_summary
+        onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
 
-        DoubleField {
-          name: "comparison_n"
-          label: ""
-          defaultValue: 20
-          min: 2
-          fieldWidth: jaspTheme.textFieldWidth
-          enabled: from_summary.checked
-                  onEditingFinished : {
+      DoubleField {
+        name: "comparison_n"
+        label: ""
+        defaultValue: 20
+        min: 2
+        fieldWidth: jaspTheme.textFieldWidth
+        enabled: switch_source.is_summary
+        onEditingFinished : {
           summary_dirty.checked = true
         }
-        }
+      }
 
 
 
-        Label {
-          text: qsTr("<i>X</i>-variable name")
-        }
+      Label {
+        text: qsTr("<i>X</i>-variable name")
+      }
 
-        TextField
-        {
-          name: "x_variable_name"
-          id: x_variable_name
-          placeholderText: qsTr("X variable")
-          enabled: from_summary.checked
-           Layout.columnSpan: 2
-           fieldWidth: jaspTheme.textFieldWidth * 2
-        }
+      TextField
+      {
+        name: "x_variable_name"
+        id: x_variable_name
+        placeholderText: qsTr("X variable")
+        enabled: switch_source.is_summary
+        Layout.columnSpan: 2
+        fieldWidth: jaspTheme.textFieldWidth * 2
+      }
 
-        Label {
-          text: qsTr("<i>Y</i>-variable name")
-        }
+      Label {
+        text: qsTr("<i>Y</i>-variable name")
+      }
 
-        TextField
-        {
-          name: "y_variable_name"
-          id: y_variable_name
-          placeholderText: qsTr("Y variable")
-          enabled: from_summary.checked
-           Layout.columnSpan: 2
-           fieldWidth: jaspTheme.textFieldWidth * 2
-        }
+      TextField
+      {
+        name: "y_variable_name"
+        id: y_variable_name
+        placeholderText: qsTr("Y variable")
+        enabled: switch_source.is_summary
+        Layout.columnSpan: 2
+        fieldWidth: jaspTheme.textFieldWidth * 2
+      }
 
-        Label {
-          text: qsTr("Grouping variable name")
-        }
-
-
-        TextField
-        {
-          name: "grouping_variable_name"
-          id: grouping_variable_name
-          placeholderText: qsTr("Grouping variable")
-          enabled: from_summary.checked
-           Layout.columnSpan: 2
-           fieldWidth: jaspTheme.textFieldWidth * 2
-        }
-      } // end of 3 column grid
+      Label {
+        text: qsTr("Grouping variable name")
+      }
 
 
+      TextField
+      {
+        name: "grouping_variable_name"
+        id: grouping_variable_name
+        placeholderText: qsTr("Grouping variable")
+        enabled: switch_source.is_summary
+        Layout.columnSpan: 2
+        fieldWidth: jaspTheme.textFieldWidth * 2
+      }
+    } // end of 3 column grid
 
-                        CheckBox
-	    {
-	      name: "summary_dirty";
-	      id: summary_dirty
-	      visible: false
-	    }
 
-    }  // end of group for summary
+
+    CheckBox
+    {
+      name: "summary_dirty";
+      id: summary_dirty
+      visible: false
+    }
+
+  }  // end of group for summary
+
+
+  Group
+  {
+    title: qsTr("<b>Analysis options</b>")
+    Esci.ConfLevel
+    {
+      name: "conf_level"
+      id: conf_level
+      onFocusChanged: {
+        alpha_adjust()
+      }
+    }
 
   }
 
-	Group
-	{
-		title: qsTr("<b>Analysis options</b>")
-		Layout.columnSpan: 2
-		Esci.ConfLevel
-		  {
-		    name: "conf_level"
-		    id: conf_level
-		    onFocusChanged: {
-         alpha_adjust()
-        }
-		  }
-
-	}
-
-	Group
-	{
-	  title: qsTr("<b>Results options</b>")
-	  CheckBox
-	  {
-	    name: "show_details";
-	    label: qsTr("Extra details")
-	   }
+  Group
+  {
+    title: qsTr("<b>Results options</b>")
+    CheckBox
+    {
+      name: "show_details";
+      label: qsTr("Extra details")
+    }
   }
 
 
   Group {
     title: qsTr("<b>Regression</b>")
-    enabled: from_raw.checked
-    visible: from_raw.checked
-    Layout.columnSpan: 2
+    visible: !switch_source.is_summary
 
-	  GridLayout {
-	    columns: 2
+    GridLayout {
+      columns: 2
 
-	      CheckBox {
-    	    name: "show_line";
-    	    id: show_line
-	        label: qsTr("Line")
-	        enabled: do_regression.checked
-          visible: from_raw.checked
-	      }
+      CheckBox {
+        name: "show_line";
+        id: show_line
+        label: qsTr("Line")
+        enabled: do_regression.checked
+        visible: !switch_source.is_summary
+      }
 
-	      CheckBox {
-    	    name: "show_line_CI";
-    	    id: show_line_CI
-	        label: qsTr("CI on Line")
-	        enabled: do_regression.checked
-          visible: from_raw.checked
-	      }
+      CheckBox {
+        name: "show_line_CI";
+        id: show_line_CI
+        label: qsTr("CI on Line")
+        enabled: do_regression.checked
+        visible: !switch_source.is_summary
+      }
 
-	  }
+    }
 
 
   } // end of regression
@@ -305,16 +278,16 @@ Form
   Esci.ScatterplotOptions {
     sp_other_options_grid_enabled: false
     sp_other_options_grid_visible: false
+    is_summary: switch_source.is_summary
+  }
 
 
-    Section
+  Section
   {
     title: qsTr("Scatterplot aesthetics")
-    enabled: from_raw.checked
-    visible: from_raw.checked
+    visible: !switch_source.is_summary
 
-
-      GridLayout {
+    GridLayout {
       id: grid
       columns: 4
 
@@ -363,7 +336,7 @@ Form
         name: "sp_shape_raw_reference"
         id: sp_shape_raw_reference
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ShapeSelect
@@ -371,7 +344,7 @@ Form
         name: "sp_shape_raw_comparison"
         id: sp_shape_raw_comparison
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -380,7 +353,7 @@ Form
         name: "shape_raw_unused"
         id: shape_raw_unused
         startValue: 'circle filled'
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -393,7 +366,7 @@ Form
         name: "sp_size_raw_reference"
         id: sp_size_raw_reference
         defaultValue: 3
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -402,7 +375,7 @@ Form
         name: "sp_size_raw_comparison"
         id: sp_size_raw_comparison
         defaultValue: 3
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -411,7 +384,7 @@ Form
         name: "sp_size_raw_unused"
         id: sp_size_raw_unused
         defaultValue: 2
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
 
       }
 
@@ -424,7 +397,7 @@ Form
         name: "sp_color_raw_reference"
         id: sp_color_raw_reference
         startValue: "black"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -432,7 +405,7 @@ Form
         name: "sp_color_raw_comparison"
         id: sp_color_raw_comparison
         startValue: "black"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -440,7 +413,7 @@ Form
         name: "sp_color_raw_unused"
         id: sp_color_raw_unused
         startValue: "black"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -453,7 +426,7 @@ Form
         name: "sp_fill_raw_reference"
         id: sp_fill_raw_reference
         startValue: "#008DF9"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -461,7 +434,7 @@ Form
         name: "sp_fill_raw_comparison"
         id: sp_fill_raw_comparison
         startValue: "#009F81"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
       Esci.ColorSelect
@@ -469,7 +442,7 @@ Form
         name: "sp_fill_raw_unused"
         id: sp_fill_raw_unused
         startValue: "NA"
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
       }
 
 
@@ -481,7 +454,7 @@ Form
       {
         name: "sp_alpha_raw_reference"
         id: sp_alpha_raw_reference
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         defaultValue: 75
 
       }
@@ -490,7 +463,7 @@ Form
       {
         name: "sp_alpha_raw_comparison"
         id: sp_alpha_raw_comparison
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         defaultValue: 75
 
       }
@@ -499,7 +472,7 @@ Form
       {
         name: "sp_alpha_raw_unused"
         id: sp_alpha_raw_unused
-        enabled: from_raw.checked
+        enabled: !switch_source.is_summary
         defaultValue: 75
 
       }
@@ -623,12 +596,9 @@ Form
   } // end scatterplot aesthetics
 
 
-
-  }
-
-
   Esci.FigureOptions {
     title: qsTr("Estimation figure options")
+    is_summary: switch_source.is_summary
     simple_labels_enabled: false
     simple_labels_visible: false
     difference_axis_grid_visible: true
@@ -639,9 +609,10 @@ Form
     ymax_placeholderText: "1"
     width_defaultValue: 600
     height_defaultValue: 400
+  }
 
 
-    Section
+  Section
   {
     title: qsTr("Estimation figure aesthetics")
 
@@ -681,12 +652,7 @@ Form
         id: linetype_summary_difference
       }
 
-
-
     }
-
-
-  }
 
   }
 

--- a/inst/qml/jasp_meta_mdiff_two.qml
+++ b/inst/qml/jasp_meta_mdiff_two.qml
@@ -24,211 +24,184 @@ import "./esci" as Esci
 
 Form
 {
-	id: form
-	property int framework:	Common.Type.Framework.Classical
+  id: form
 
-	function dlab() {
-    if (from_raw.checked) {
-      reference_means.label = qsTr("Reference means (<i>M</i><sub>reference</sub>)")
-    } else {
-      reference_means.label = qsTr("Standardized mean differences, bias corrected")
-    }
+  function dlab() {
+	if (from_raw.checked) {
+	  reference_means.label = qsTr("Reference means (<i>M</i><sub>reference</sub>)")
+	} else {
+	  reference_means.label = qsTr("Standardized mean differences, bias corrected")
+	}
   }
 
 
   RadioButtonGroup {
-    columns: 2
-    name: "switch"
-    id: switch_source
+	columns: 2
+	name: "switch"
+	id: switch_source
 
-    RadioButton {
-      value: "from_raw";
-      label: qsTr("Analyze original units");
-      checked: true;
-      id: from_raw
-      onClicked: {
-         dlab()
-      }
-    }
+	RadioButton {
+	  value: "from_raw";
+	  label: qsTr("Analyze original units");
+	  checked: true;
+	  id: from_raw
+	  onClicked: {
+		dlab()
+	  }
+	}
 
-    RadioButton {
-      value: "from_d";
-      label: qsTr("Analyze Cohen's <i>d</i>");
-      id: from_d
-      onClicked: {
-         dlab()
-      }
-    }
+	RadioButton {
+	  value: "from_d";
+	  label: qsTr("Analyze Cohen's <i>d</i>");
+	  id: from_d
+	  onClicked: {
+		dlab()
+	  }
+	}
   }
 
-      	VariablesForm {
-      	  height: 200
-      		AvailableVariablesList {
-      		  name: "allVariablesList"
-      		}
-
-      		AssignedVariablesList {
-      		  name: "reference_means";
-      		  id: reference_means
-      		  label: qsTr("Reference means (<i>M</i><sub>reference</sub>)");
-      		  allowedColumns: ["scale"];
-      		  singleVariable: true
-      		}
-      		AssignedVariablesList {
-      		  name: "reference_sds";
-      		  title: qsTr("Reference standard deviations (<i>s</i><sub>reference</sub>)");
-      		  allowedColumns: ["scale"];
-      		  singleVariable: true
-      		  enabled: from_raw.checked
-      		  visible: from_raw.checked
-      		}
-      		AssignedVariablesList {
-      		  name: "reference_ns";
-      		  title: qsTr("Reference sample sizes (<i>N</i><sub>reference</sub>)");
-      		  allowedColumns: ["scale"];
-      		  singleVariable: true
-      		}
-      		AssignedVariablesList {
-      		  name: "comparison_means";
-      		  id: comparison_means
-      		  label: qsTr("Comparison means (<i>M</i><sub>comparison</sub>)");
-      		  allowedColumns: ["scale"];
-      		  singleVariable: true
-      		  enabled: from_raw.checked
-      		  visible: from_raw.checked
-      		}
-      		AssignedVariablesList {
-      		  name: "comparison_sds";
-      		  title: qsTr("Comparison standard deviations (<i>s</i><sub>comparison</sub>)");
-      		  allowedColumns: ["scale"];
-      		  singleVariable: true
-      		  enabled: from_raw.checked
-      		  visible: from_raw.checked
-      		}
-      		AssignedVariablesList {
-      		  name: "comparison_ns";
-      		  title: qsTr("Comparison sample sizes (<i>N</i><sub>comparison</sub>)");
-      		  allowedColumns: ["scale"];
-      		  singleVariable: true
-      		}
-      		AssignedVariablesList {
-      		  name: "r";
-      		  title: qsTr("<i>r</i> (Optional; leave blank for between-subjects)");
-      		  allowedColumns: ["scale"];
-      		  singleVariable: true
-      		}
-      		AssignedVariablesList {
-      		  name: "labels";
-      		  title: qsTr("Study labels (optional");
-      		  allowedColumns: ["nominal"];
-      		  singleVariable: true
-      		}
-      		AssignedVariablesList {
-      		  name: "moderator";
-      		  id: moderator;
-      		  title: qsTr("Moderator (optional");
-      		  allowedColumns: ["nominal"];
-      		  singleVariable: true
-      		}
-      	}
-
-
-  Label {
-        text: " "
-      }
-
-  Label {
-        text: " "
-      }
-
-  Label {
-        text: " "
-      }
-
-  Label {
-        text: " "
-      }
-
-  Label {
-        text: " "
-      }
-
-  Label {
-        text: " "
-      }
-
-
-
-
-	Group {
-		title: qsTr("<b>Analysis options</b>")
-		columns: 1
-		Layout.rowSpan: 1
-
-		Esci.ConfLevel {
-		    name: "conf_level"
-		    id: conf_level
-		}
-
-    TextField {
-        name: "effect_label"
-        label: qsTr("Effect label")
-        placeholderText: qsTr("My effect")
-    }
-
-		DropDown {
-        name: "reported_effect_size"
-        label: qsTr("Effect size")
-        startValue: 'mean_difference'
-        enabled: from_raw.checked
-        values:
-          [
-            { label: qsTr("Original units"), value: "mean_difference"},
-            { label: qsTr("Standardized mean difference"), value: "smd_unbiased"}
-          ]
-        id: effect_size
-    }
-
-    CheckBox {
-	    name: "assume_equal_variance";
-	    id: assume_equal_variance
-	    checked: true;
-	    label: qsTr("Assume equal variances")
-	  }
-
-    DropDown {
-        name: "random_effects"
-        label: qsTr("Model")
-        startValue: 'random_effects'
-        values:
-          [
-            { label: qsTr("Random effects (RE)"), value: "random_effects"},
-            { label: qsTr("Fixed effect (FE)"), value: "fixed_effects"},
-            { label: qsTr("Compare fixed and random effects"), value: "compare"}
-          ]
-        id: random_effects
-    }
+  VariablesForm {
+	preferredHeight: 460 * jaspTheme.uiScale
+	removeInvisibles: true
+	AvailableVariablesList {
+	  name: "allVariablesList"
 	}
 
-	Group {
-	  title: qsTr("<b>Results options</b>")
-		columns: 1
-		Layout.columnSpan: 2
-
-	  CheckBox {
-	    name: "show_details";
-	    id: show_details
-	    label: qsTr("Extra details")
-	  }
-
-	  CheckBox {
-	    name: "include_PIs";
-	    label: qsTr("Prediction intervals")
-	    enabled: random_effects.currentValue == "random_effects"
-	  }
-
-
+	AssignedVariablesList {
+	  name: "reference_means";
+	  id: reference_means
+	  label: qsTr("Reference means (<i>M</i><sub>reference</sub>)");
+	  allowedColumns: ["scale"];
+	  singleVariable: true
 	}
+	AssignedVariablesList {
+	  name: "reference_sds";
+	  title: qsTr("Reference standard deviations (<i>s</i><sub>reference</sub>)");
+	  allowedColumns: ["scale"];
+	  singleVariable: true
+	  enabled: from_raw.checked
+	  visible: from_raw.checked
+	}
+	AssignedVariablesList {
+	  name: "reference_ns";
+	  title: qsTr("Reference sample sizes (<i>N</i><sub>reference</sub>)");
+	  allowedColumns: ["scale"];
+	  singleVariable: true
+	}
+	AssignedVariablesList {
+	  name: "comparison_means";
+	  id: comparison_means
+	  label: qsTr("Comparison means (<i>M</i><sub>comparison</sub>)");
+	  allowedColumns: ["scale"];
+	  singleVariable: true
+	  enabled: from_raw.checked
+	  visible: from_raw.checked
+	}
+	AssignedVariablesList {
+	  name: "comparison_sds";
+	  title: qsTr("Comparison standard deviations (<i>s</i><sub>comparison</sub>)");
+	  allowedColumns: ["scale"];
+	  singleVariable: true
+	  enabled: from_raw.checked
+	  visible: from_raw.checked
+	}
+	AssignedVariablesList {
+	  name: "comparison_ns";
+	  title: qsTr("Comparison sample sizes (<i>N</i><sub>comparison</sub>)");
+	  allowedColumns: ["scale"];
+	  singleVariable: true
+	}
+	AssignedVariablesList {
+	  name: "r";
+	  title: qsTr("<i>r</i> (Optional; leave blank for between-subjects)");
+	  allowedColumns: ["scale"];
+	  singleVariable: true
+	}
+	AssignedVariablesList {
+	  name: "labels";
+	  title: qsTr("Study labels (optional");
+	  allowedColumns: ["nominal"];
+	  singleVariable: true
+	}
+	AssignedVariablesList {
+	  name: "moderator";
+	  id: moderator;
+	  title: qsTr("Moderator (optional");
+	  allowedColumns: ["nominal"];
+	  singleVariable: true
+	}
+  }
+
+
+  Group {
+	title: qsTr("<b>Analysis options</b>")
+	columns: 1
+	Layout.rowSpan: 1
+
+	Esci.ConfLevel {
+	  name: "conf_level"
+	  id: conf_level
+	}
+
+	TextField {
+	  name: "effect_label"
+	  label: qsTr("Effect label")
+	  placeholderText: qsTr("My effect")
+	}
+
+	DropDown {
+	  name: "reported_effect_size"
+	  label: qsTr("Effect size")
+	  startValue: 'mean_difference'
+	  enabled: from_raw.checked
+	  values:
+		  [
+		{ label: qsTr("Original units"), value: "mean_difference"},
+		{ label: qsTr("Standardized mean difference"), value: "smd_unbiased"}
+	  ]
+	  id: effect_size
+	}
+
+	CheckBox {
+	  name: "assume_equal_variance";
+	  id: assume_equal_variance
+	  checked: true;
+	  label: qsTr("Assume equal variances")
+	}
+
+	DropDown {
+	  name: "random_effects"
+	  label: qsTr("Model")
+	  startValue: 'random_effects'
+	  values:
+		  [
+		{ label: qsTr("Random effects (RE)"), value: "random_effects"},
+		{ label: qsTr("Fixed effect (FE)"), value: "fixed_effects"},
+		{ label: qsTr("Compare fixed and random effects"), value: "compare"}
+	  ]
+	  id: random_effects
+	}
+  }
+
+  Group {
+	title: qsTr("<b>Results options</b>")
+	columns: 1
+	Layout.columnSpan: 2
+
+	CheckBox {
+	  name: "show_details";
+	  id: show_details
+	  label: qsTr("Extra details")
+	}
+
+	CheckBox {
+	  name: "include_PIs";
+	  label: qsTr("Prediction intervals")
+	  enabled: random_effects.currentValue == "random_effects"
+	}
+
+
+  }
 
   Esci.MetaFigureOptions {
 

--- a/inst/qml/jasp_meta_mean.qml
+++ b/inst/qml/jasp_meta_mean.qml
@@ -25,7 +25,6 @@ import "./esci" as Esci
 Form
 {
 	id: form
-	property int framework:	Common.Type.Framework.Classical
 
 	function dlab() {
     if (from_raw.checked) {

--- a/inst/qml/jasp_meta_pdiff_two.qml
+++ b/inst/qml/jasp_meta_pdiff_two.qml
@@ -25,7 +25,6 @@ import "./esci" as Esci
 Form
 {
 	id: form
-	property int framework:	Common.Type.Framework.Classical
 
 
       	VariablesForm {

--- a/inst/qml/jasp_meta_proportion.qml
+++ b/inst/qml/jasp_meta_proportion.qml
@@ -25,8 +25,6 @@ import "./esci" as Esci
 Form
 {
 	id: form
-	property int framework:	Common.Type.Framework.Classical
-
 
       	VariablesForm {
       	  height: 40

--- a/inst/qml/jasp_meta_r.qml
+++ b/inst/qml/jasp_meta_r.qml
@@ -25,8 +25,6 @@ import "./esci" as Esci
 Form
 {
 	id: form
-	property int framework:	Common.Type.Framework.Classical
-
 
       	VariablesForm {
       	  height: 40


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3979

The Summary stats of the ESCI are now available even without data.
I have made also some changes in QML: there were some QML errors (references to Common.Type.Framework.Classical, or inexisting items, also some issues with columnSpan and Sections).
Correlation and Proportion analyses work without data, but The Means and Medians analyses give an engine error. I suspect that these analyses are not yet ready to run without data. @rcalinjageman Can you have a look?